### PR TITLE
fix Python shebang

### DIFF
--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # Copyright 2016 Adobe. All rights reserved.
 
 # Methods:

--- a/python/psautohint/fdTools.py
+++ b/python/psautohint/fdTools.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # Copyright 2014 Adobe. All rights reserved.
 
 from __future__ import print_function, absolute_import


### PR DESCRIPTION
The standard shebang for Python if you want to allow users to use whatever Python is in their path is
`#!/usr/bin/env python'

I noticed this issue while packaging psautohint for [Debian](https://lintian.debian.org/tags/script-uses-bin-env.html) .