### PR TITLE
Move ACOptions back to autohint.py

### DIFF
--- a/python/psautohint/__main__.py
+++ b/python/psautohint/__main__.py
@@ -16,7 +16,7 @@ import textwrap
 from fontTools.misc.py23 import open
 
 from psautohint._psautohint import version as PSAUTOHINT_VERSION
-from psautohint.autohint import hintFiles, ACFontError, ACHintError, logMsg
+from psautohint.autohint import hintFiles, ACOptions, ACFontError, ACHintError, logMsg
 from psautohint.ufoFont import UFOParseError
 from psautohint.ufoFont import kProcessedGlyphsLayer as PROCD_GLYPHS_LAYER
 
@@ -327,8 +327,9 @@ def _process_glyph_list_arg(glyph_list, name_aliases):
     return filter(None, glyph_list)
 
 
-class ACOptions(object):
+class Options(ACOptions):
     def __init__(self, pargs):
+        super(Options, self).__init__()
         self.inputPaths = pargs.font_paths
         self.outputPath = pargs.output_path
         self.reference_font = pargs.reference_font
@@ -344,14 +345,6 @@ class ACOptions(object):
         self.printFDDictList = pargs.print_list_fddict
         self.allowDecimalCoords = pargs.decimal
         self.writeToDefaultLayer = pargs.write_to_default_layer
-
-        self.glyphList = []
-        self.excludeGlyphList = False
-        self.nameAliases = {}
-        self.hCounterGlyphs = []
-        self.vCounterGlyphs = []
-        self.baseMaster = {}
-        self.font_format = None
 
 
 class _CustomHelpFormatter(argparse.RawDescriptionHelpFormatter):
@@ -706,7 +699,7 @@ def get_options(args):
     else:
         all_font_paths = parsed_args.font_paths
 
-    options = ACOptions(parsed_args)
+    options = Options(parsed_args)
 
     options.font_format = _validate_font_paths(all_font_paths, parser)
 

--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -52,6 +52,33 @@ kTempCFFSuffix = ".temp.ac.cff"
 kProgressChar = "."
 
 
+class ACOptions(object):
+    def __init__(self):
+        self.inputPaths = []
+        self.outputPath = None
+        self.glyphList = []
+        self.nameAliases = {}
+        self.excludeGlyphList = False
+        self.usePlistFile = False
+        self.hintAll = False
+        self.rehint = False
+        self.verbose = True
+        self.allowChanges = False
+        self.noFlex = False
+        self.noHintSub = False
+        self.allow_no_blues = False
+        self.hCounterGlyphs = []
+        self.vCounterGlyphs = []
+        self.logOnly = False
+        self.logFile = None
+        self.printDefaultFDDict = False
+        self.printFDDictList = False
+        self.allowDecimalCoords = False
+        self.writeToDefaultLayer = False
+        self.baseMaster = {}
+        self.font_format = None
+
+
 class ACFontError(Exception):
     pass
 


### PR DESCRIPTION
`autohint.hintFiles` take `ACOptions` as argument, but having `ACOptions` not defined in `autohint.py` means every caller needs to define it by itself, which is not good. Move it back, and add a subclass in `__main__.py` that takes parsed args as an argument.