### PR TITLE
Calculate coverage for C code as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,13 @@ matrix:
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
+    - os: linux
+      before_install: false
+      install:
+        - pip install tox
+      script:
+        - tox -e coverage-c
+      after_success: false
     - os: osx
       language: generic
       env:

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,26 @@ commands =
   coverage html
   diff-cover --compare-branch {env:DIFF_AGAINST:origin/master} {toxworkdir}/coverage.xml
 
+[testenv:coverage-c]
+description = generate coverage for C library
+basepython = {env:TOXPYTHON:python}
+deps =
+  {[testenv]deps}
+  codecov
+  pytest-xdist
+skip_install = true
+setenv =
+  CFLAGS = --coverage
+  BUILD_DIR = {envdir}/build
+  LIB_DIR = {env:BUILD_DIR}/lib
+  PYTHONPATH = {env:PYTHONPATH:}{:}{env:LIB_DIR}
+passenv = TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_*
+changedir = {toxinidir}
+commands =
+  python setup.py build --build-base {env:BUILD_DIR} --build-platlib {env:LIB_DIR}
+  pytest -n {env:PYTEST_NUM_PROCESSES:auto} {posargs}
+  codecov --env {envname}
+
 [testenv:codecov]
 description = upload coverage data to codecov (only run on CI)
 basepython = {env:TOXPYTHON:python}


### PR DESCRIPTION
Add a tox environment, coverage-c, to be run on CI. A bit messy but seems to work and ~~not~~ now Codecov shows combined coverage for both C and Python code.