### PR TITLE
tox: run codecov in separate 'coverage-codecov-c' env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
       install:
         - pip install tox
       script:
-        - tox -e coverage-c
+        - tox -e coverage-codecov-c
       after_success: false
     - os: osx
       language: generic

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,6 @@ description = generate coverage for C library
 basepython = {env:TOXPYTHON:python}
 deps =
   {[testenv]deps}
-  codecov
   pytest-xdist
 skip_install = true
 setenv =
@@ -64,10 +63,9 @@ changedir = {toxinidir}
 commands =
   python setup.py build --build-base {env:BUILD_DIR} --build-platlib {env:LIB_DIR}
   pytest -n {env:PYTEST_NUM_PROCESSES:auto} {posargs}
-  codecov --env {envname}
 
 [testenv:codecov]
-description = upload coverage data to codecov (only run on CI)
+description = upload Python coverage data to codecov (only run on CI)
 basepython = {env:TOXPYTHON:python}
 deps =
   {[testenv:coverage]deps}
@@ -79,6 +77,20 @@ changedir = {toxinidir}
 commands =
   coverage combine
   codecov --env TOXENV
+
+[testenv:coverage-codecov-c]
+description = generate C coverage data and upload to codecov (only run on CI)
+basepython = {env:TOXPYTHON:python}
+deps =
+  {[testenv:coverage-c]deps}
+  codecov
+skip_install = true
+setenv = {[testenv:coverage-c]setenv}
+passenv = {[testenv:coverage-c]passenv}
+changedir = {toxinidir}
+commands =
+  {[testenv:coverage-c]commands}
+  codecov --env {envname}
 
 [testenv:sdist]
 description = build sdist to be uploaded to PyPI


### PR DESCRIPTION
This allows to run 'tox -e coverage-c' locally on a dev's machine, without running codecov at the end (which fails unless run from the CI).