### PR TITLE
Add --traceback option

### DIFF
--- a/python/psautohint/__main__.py
+++ b/python/psautohint/__main__.py
@@ -641,6 +641,11 @@ def get_options(args):
         action='version',
         version=__version__
     )
+    parser.add_argument(
+        '--traceback',
+        action='store_true',
+        help="show traceback for exceptions.",
+    )
     parsed_args = parser.parse_args(args)
 
     if parsed_args.verbose == 0:
@@ -697,17 +702,19 @@ def get_options(args):
     else:
         _parse_fontinfo_file(options, parsed_args.fontinfo_file)
 
-    return options
+    return options, parsed_args
 
 
 def main(args=None):
-    options = get_options(args)
+    options, pargs = get_options(args)
 
     try:
         hintFiles(options)
-    except Exception:
-        logging.exception("Unhandled exception occurred")
-        raise
+    except Exception as ex:
+        if pargs.traceback:
+            raise
+        logging.error(ex)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -165,7 +165,7 @@ def test_missing_glyph_list(glyphs, tmpdir):
     out = str(tmpdir / basename(path)) + ".out"
 
     with pytest.raises(FontParseError):
-        autohint([path, '-o', out, '-g', glyphs])
+        autohint([path, '--traceback', '-o', out, '-g', glyphs])
 
 
 @pytest.mark.parametrize("path", ["%s/dummy/fontinfo" % DATA_DIR, DATA_DIR])
@@ -174,12 +174,16 @@ def test_unsupported_format(path):
         autohint([path])
 
 
-def test_missing_cff_table(tmpdir):
+@pytest.mark.parametrize("option,exception", [
+    ([], SystemExit),
+    (['--traceback'], FontParseError),
+])
+def test_missing_cff_table(option, exception, tmpdir):
     path = "%s/dummy/nocff.otf" % DATA_DIR
     out = str(tmpdir / basename(path)) + ".out"
 
-    with pytest.raises(FontParseError):
-        autohint([path, '-o', out])
+    with pytest.raises(exception):
+        autohint([path, '-o', out] + option)
 
 
 @pytest.mark.parametrize("option,argument", [


### PR DESCRIPTION
Hide the traceback by default and add a `--traceback` option to show it.