### PR TITLE
Pass floats to report callbacks

### DIFF
--- a/libpsautohint/autohintexe.c
+++ b/libpsautohint/autohintexe.c
@@ -83,35 +83,35 @@ printHelp(void)
 }
 
 static void
-charZoneCB(int top, int bottom, char* glyphName)
+charZoneCB(float top, float bottom, char* glyphName)
 {
     if (reportFile)
-        fprintf(reportFile, "charZone %s top %f bottom %f\n", glyphName,
-                top / 256.0, bottom / 256.0);
+        fprintf(reportFile, "charZone %s top %f bottom %f\n", glyphName, top,
+                bottom);
 }
 
 static void
-stemZoneCB(int top, int bottom, char* glyphName)
+stemZoneCB(float top, float bottom, char* glyphName)
 {
     if (reportFile)
-        fprintf(reportFile, "stemZone %s top %f bottom %f\n", glyphName,
-                top / 256.0, bottom / 256.0);
+        fprintf(reportFile, "stemZone %s top %f bottom %f\n", glyphName, top,
+                bottom);
 }
 
 static void
-hstemCB(int top, int bottom, char* glyphName)
+hstemCB(float top, float bottom, char* glyphName)
 {
     if (reportFile)
-        fprintf(reportFile, "HStem %s top %f bottom %f\n", glyphName,
-                top / 256.0, bottom / 256.0);
+        fprintf(reportFile, "HStem %s top %f bottom %f\n", glyphName, top,
+                bottom);
 }
 
 static void
-vstemCB(int right, int left, char* glyphName)
+vstemCB(float right, float left, char* glyphName)
 {
     if (reportFile)
-        fprintf(reportFile, "VStem %s right %f left %f\n", glyphName,
-                right / 256.0, left / 256.0);
+        fprintf(reportFile, "VStem %s right %f left %f\n", glyphName, right,
+                left);
 }
 
 static void

--- a/libpsautohint/include/psautohint.h
+++ b/libpsautohint/include/psautohint.h
@@ -87,7 +87,7 @@ ACLIB_API void AC_SetReportCB(AC_REPORTFUNCPTR reportCB);
  * belongs to the AC lib. It should be copied immediately - it may may last
  * past the return of the callback.
  */
-typedef void (*AC_REPORTSTEMPTR)(int top, int bottom, char* glyphName);
+typedef void (*AC_REPORTSTEMPTR)(float top, float bottom, char* glyphName);
 
 ACLIB_API void AC_SetReportStemsCB(AC_REPORTSTEMPTR hstemCB,
                                    AC_REPORTSTEMPTR vstemCB,
@@ -103,7 +103,7 @@ ACLIB_API void AC_SetReportStemsCB(AC_REPORTSTEMPTR hstemCB,
  * belongs to the AC lib. It should be copied immediately - it may may last
  * past the return of the callback.
  */
-typedef void (*AC_REPORTZONEPTR)(int top, int bottom, char* glyphName);
+typedef void (*AC_REPORTZONEPTR)(float top, float bottom, char* glyphName);
 
 ACLIB_API void AC_SetReportZonesCB(AC_REPORTZONEPTR charCB,
                                    AC_REPORTZONEPTR stemCB);

--- a/libpsautohint/src/stemreport.c
+++ b/libpsautohint/src/stemreport.c
@@ -15,9 +15,8 @@ AddVStem(Fixed right, Fixed left, bool curved)
     if (curved && !gAllStems)
         return;
 
-    if (gAddVStemCB != NULL) {
-        gAddVStemCB(right, left, gGlyphName);
-    }
+    if (gAddVStemCB)
+        gAddVStemCB(FIXED2FLOAT(right), FIXED2FLOAT(left), gGlyphName);
 }
 
 void
@@ -26,23 +25,20 @@ AddHStem(Fixed top, Fixed bottom, bool curved)
     if (curved && !gAllStems)
         return;
 
-    if (gAddHStemCB != NULL) {
-        gAddHStemCB(top, bottom, gGlyphName);
-    }
+    if (gAddHStemCB)
+        gAddHStemCB(FIXED2FLOAT(top), FIXED2FLOAT(bottom), gGlyphName);
 }
 
 void
 AddGlyphExtremes(Fixed bot, Fixed top)
 {
-    if (gAddGlyphExtremesCB != NULL) {
-        gAddGlyphExtremesCB(top, bot, gGlyphName);
-    }
+    if (gAddGlyphExtremesCB)
+        gAddGlyphExtremesCB(FIXED2FLOAT(top), FIXED2FLOAT(bot), gGlyphName);
 }
 
 void
 AddStemExtremes(Fixed bot, Fixed top)
 {
-    if (gAddStemExtremesCB != NULL) {
-        gAddStemExtremesCB(top, bot, gGlyphName);
-    }
+    if (gAddStemExtremesCB)
+        gAddStemExtremesCB(FIXED2FLOAT(top), FIXED2FLOAT(bot), gGlyphName);
 }


### PR DESCRIPTION
The fixed point integers used by the autohinter is an implementation detail and shouldn’t leak into the API.