### PR TITLE
Add psstemhist tool

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -42,3 +42,13 @@ function run_tests {
     # container can lead to permission errors
     rm -rf .tox
 }
+
+# override default 'install_delocate' as a temporary workaround for
+# autohintexe embedded executable losing execute permissions on macOS
+# https://github.com/matthew-brett/delocate/issues/42
+# https://github.com/matthew-brett/delocate/pull/43
+# https://github.com/adobe-type-tools/psautohint/pull/116
+function install_delocate {
+    check_pip
+    $PIP_CMD install git+https://github.com/anthrotype/delocate.git@fix-exe-permissions#egg=delocate
+}

--- a/config.sh
+++ b/config.sh
@@ -48,7 +48,8 @@ function run_tests {
 # https://github.com/matthew-brett/delocate/issues/42
 # https://github.com/matthew-brett/delocate/pull/43
 # https://github.com/adobe-type-tools/psautohint/pull/116
+# TODO: remove this once new delocate with the above patch is released
 function install_delocate {
     check_pip
-    $PIP_CMD install git+https://github.com/anthrotype/delocate.git@fix-exe-permissions#egg=delocate
+    $PIP_CMD install git+https://github.com/matthew-brett/delocate.git#egg=delocate
 }

--- a/libpsautohint/autohintexe.c
+++ b/libpsautohint/autohintexe.c
@@ -190,7 +190,7 @@ getFileData(char* name)
 }
 
 static void
-writeFileData(char* name, char* output, char* fSuffix)
+writeFileData(char* name, char* output, size_t outputsize, char* fSuffix)
 {
     FILE* fp;
 
@@ -207,7 +207,7 @@ writeFileData(char* name, char* output, char* fSuffix)
     } else
         fp = fopen(name, "w");
 
-    fwrite(output, 1, strlen(output), fp);
+    fwrite(output, 1, outputsize, fp);
     fclose(fp);
 }
 
@@ -442,9 +442,9 @@ main(int argc, char* argv[])
             } else {
                 if ((outputsize != 0) && (result == AC_Success)) {
                     if (!argumentIsBezData) {
-                        writeFileData(bezName, output, fileSuffix);
+                        writeFileData(bezName, output, outputsize, fileSuffix);
                     } else {
-                        fprintf(stdout, "%s", output);
+                        fwrite(output, 1, outputsize, stdout);
                     }
                 }
             }
@@ -493,7 +493,7 @@ main(int argc, char* argv[])
                            (const char**)masters, outGlyphs, outputSizes);
 
         for (i = 0; i < total_files; i++) {
-            writeFileData(masters[i], outGlyphs[i], "new");
+            writeFileData(masters[i], outGlyphs[i], outputSizes[i], "new");
             free(masters[i]);
             free(inGlyphs[i]);
             free(outGlyphs[i]);

--- a/libpsautohint/autohintexe.c
+++ b/libpsautohint/autohintexe.c
@@ -155,21 +155,21 @@ getFileData(char* name)
     struct stat filestat;
     if ((stat(name, &filestat)) < 0) {
         fprintf(stderr,
-                "Error. Could not open file '%s'. Please check "
+                "ERROR: Could not open file '%s'. Please check "
                 "that it exists and is not write-protected.\n",
                 name);
         exit(AC_FatalError);
     }
 
     if (filestat.st_size == 0) {
-        fprintf(stderr, "Error. File '%s' has zero size.\n", name);
+        fprintf(stderr, "ERROR: File '%s' has zero size.\n", name);
         exit(AC_FatalError);
     }
 
     data = malloc(filestat.st_size + 1);
     if (data == NULL) {
         fprintf(stderr,
-                "Error. Could not allcoate memory for contents of file %s.\n",
+                "ERROR: Could not allcoate memory for contents of file %s.\n",
                 name);
         exit(AC_FatalError);
     } else {
@@ -177,7 +177,7 @@ getFileData(char* name)
         FILE* fp = fopen(name, "r");
         if (fp == NULL) {
             fprintf(stderr,
-                    "Error. Could not open file '%s'. Please check "
+                    "ERROR: Could not open file '%s'. Please check "
                     "that it exists and is not write-protected.\n",
                     name);
             exit(AC_FatalError);
@@ -278,7 +278,7 @@ main(int argc, char* argv[])
             total_files++;
             continue;
         } else if (firstFileNameIndex != -1) {
-            fprintf(stderr, "Error. Illegal command line. \"-\" option "
+            fprintf(stderr, "ERROR: Illegal command line. \"-\" option "
                             "found after first file name.\n");
             exit(1);
         }
@@ -304,7 +304,7 @@ main(int argc, char* argv[])
                 break;
             case 'f':
                 if (fontinfo != NULL) {
-                    fprintf(stderr, "Error. Illegal command line. \"-f\" "
+                    fprintf(stderr, "ERROR: Illegal command line. \"-f\" "
                                     "can’t be used together with the "
                                     "\"-i\" command.\n");
                     exit(1);
@@ -312,7 +312,7 @@ main(int argc, char* argv[])
                 fontInfoFileName = argv[++argi];
                 if ((fontInfoFileName[0] == '\0') ||
                     (fontInfoFileName[0] == '-')) {
-                    fprintf(stderr, "Error. Illegal command line. \"-f\" "
+                    fprintf(stderr, "ERROR: Illegal command line. \"-f\" "
                                     "option must be followed by a file "
                                     "name.\n");
                     exit(1);
@@ -321,14 +321,14 @@ main(int argc, char* argv[])
                 break;
             case 'i':
                 if (fontinfo != NULL) {
-                    fprintf(stderr, "Error. Illegal command line. \"-i\" "
+                    fprintf(stderr, "ERROR: Illegal command line. \"-i\" "
                                     "can’t be used together with the "
                                     "\"-f\" command.\n");
                     exit(1);
                 }
                 fontinfo = argv[++argi];
                 if ((fontinfo[0] == '\0') || (fontinfo[0] == '-')) {
-                    fprintf(stderr, "Error. Illegal command line. \"-i\" "
+                    fprintf(stderr, "ERROR: Illegal command line. \"-i\" "
                                     "option must be followed by a font "
                                     "info string.\n");
                     exit(1);
@@ -337,7 +337,7 @@ main(int argc, char* argv[])
             case 's':
                 fileSuffix = argv[++argi];
                 if ((fileSuffix[0] == '\0') || (fileSuffix[0] == '-')) {
-                    fprintf(stderr, "Error. Illegal command line. \"-s\" "
+                    fprintf(stderr, "ERROR: Illegal command line. \"-s\" "
                                     "option must be followed by a string, "
                                     "and the string must not begin with "
                                     "'-'.\n");
@@ -371,7 +371,7 @@ main(int argc, char* argv[])
                         report_stems = true;
                         break;
                     default:
-                        fprintf(stderr, "Error. %s is an invalid parameter.\n",
+                        fprintf(stderr, "ERROR: %s is an invalid parameter.\n",
                                 current_arg);
                         badParam = true;
                         break;
@@ -381,7 +381,7 @@ main(int argc, char* argv[])
                 printVersions();
                 exit(0);
             default:
-                fprintf(stderr, "Error. %s is an invalid parameter.\n",
+                fprintf(stderr, "ERROR: %s is an invalid parameter.\n",
                         current_arg);
                 badParam = true;
                 break;
@@ -400,12 +400,12 @@ main(int argc, char* argv[])
 
     if (firstFileNameIndex == -1) {
         fprintf(stderr,
-                "Error. Illegal command line. Must provide bez file name.\n");
+                "ERROR: Illegal command line. Must provide bez file name.\n");
         badParam = true;
     }
     if (fontinfo == NULL) {
         fprintf(stderr,
-                "Error. Illegal command line. Must provide font info.\n");
+                "ERROR: Illegal command line. Must provide font info.\n");
         badParam = true;
     }
 

--- a/libpsautohint/autohintexe.c
+++ b/libpsautohint/autohintexe.c
@@ -66,7 +66,7 @@ printHelp(void)
                     "the -f parameter for data input \n");
     fprintf(stdout, "   <name1> [name2]..[nameN]  paths to glyph bez files\n");
     fprintf(stdout, "   -b the last argument is bez data instead of a file "
-                    "name and the result will go to stdOut\n");
+                    "name and the result will go to stdout\n");
     fprintf(
       stdout,
       "   -s <suffix> Write output data to 'file name' + 'suffix', rather\n");
@@ -120,18 +120,18 @@ reportCB(char* msg, int level)
     switch (level) {
         case -1: /* LOGDEBUG */
             if (debug)
-                fprintf(stdout, "DEBUG: %s\n", msg);
+                fprintf(stderr, "DEBUG: %s\n", msg);
             break;
         case 0: /* INFO */
             if (verbose)
-                fprintf(stdout, "INFO: %s\n", msg);
+                fprintf(stderr, "INFO: %s\n", msg);
             break;
         case 1: /* WARNING */
             if (verbose)
-                fprintf(stdout, "WARNING: %s\n", msg);
+                fprintf(stderr, "WARNING: %s\n", msg);
             break;
         case 2: /* LOGERROR */
-            fprintf(stdout, "ERROR: %s\n", msg);
+            fprintf(stderr, "ERROR: %s\n", msg);
             break;
         default:
             break;
@@ -154,7 +154,7 @@ getFileData(char* name)
 
     struct stat filestat;
     if ((stat(name, &filestat)) < 0) {
-        fprintf(stdout,
+        fprintf(stderr,
                 "Error. Could not open file '%s'. Please check "
                 "that it exists and is not write-protected.\n",
                 name);
@@ -162,13 +162,13 @@ getFileData(char* name)
     }
 
     if (filestat.st_size == 0) {
-        fprintf(stdout, "Error. File '%s' has zero size.\n", name);
+        fprintf(stderr, "Error. File '%s' has zero size.\n", name);
         exit(AC_FatalError);
     }
 
     data = malloc(filestat.st_size + 1);
     if (data == NULL) {
-        fprintf(stdout,
+        fprintf(stderr,
                 "Error. Could not allcoate memory for contents of file %s.\n",
                 name);
         exit(AC_FatalError);
@@ -176,7 +176,7 @@ getFileData(char* name)
         size_t fileSize = 0;
         FILE* fp = fopen(name, "r");
         if (fp == NULL) {
-            fprintf(stdout,
+            fprintf(stderr,
                     "Error. Could not open file '%s'. Please check "
                     "that it exists and is not write-protected.\n",
                     name);
@@ -278,7 +278,7 @@ main(int argc, char* argv[])
             total_files++;
             continue;
         } else if (firstFileNameIndex != -1) {
-            fprintf(stdout, "Error. Illegal command line. \"-\" option "
+            fprintf(stderr, "Error. Illegal command line. \"-\" option "
                             "found after first file name.\n");
             exit(1);
         }
@@ -304,7 +304,7 @@ main(int argc, char* argv[])
                 break;
             case 'f':
                 if (fontinfo != NULL) {
-                    fprintf(stdout, "Error. Illegal command line. \"-f\" "
+                    fprintf(stderr, "Error. Illegal command line. \"-f\" "
                                     "can’t be used together with the "
                                     "\"-i\" command.\n");
                     exit(1);
@@ -312,7 +312,7 @@ main(int argc, char* argv[])
                 fontInfoFileName = argv[++argi];
                 if ((fontInfoFileName[0] == '\0') ||
                     (fontInfoFileName[0] == '-')) {
-                    fprintf(stdout, "Error. Illegal command line. \"-f\" "
+                    fprintf(stderr, "Error. Illegal command line. \"-f\" "
                                     "option must be followed by a file "
                                     "name.\n");
                     exit(1);
@@ -321,14 +321,14 @@ main(int argc, char* argv[])
                 break;
             case 'i':
                 if (fontinfo != NULL) {
-                    fprintf(stdout, "Error. Illegal command line. \"-i\" "
+                    fprintf(stderr, "Error. Illegal command line. \"-i\" "
                                     "can’t be used together with the "
                                     "\"-f\" command.\n");
                     exit(1);
                 }
                 fontinfo = argv[++argi];
                 if ((fontinfo[0] == '\0') || (fontinfo[0] == '-')) {
-                    fprintf(stdout, "Error. Illegal command line. \"-i\" "
+                    fprintf(stderr, "Error. Illegal command line. \"-i\" "
                                     "option must be followed by a font "
                                     "info string.\n");
                     exit(1);
@@ -337,7 +337,7 @@ main(int argc, char* argv[])
             case 's':
                 fileSuffix = argv[++argi];
                 if ((fileSuffix[0] == '\0') || (fileSuffix[0] == '-')) {
-                    fprintf(stdout, "Error. Illegal command line. \"-s\" "
+                    fprintf(stderr, "Error. Illegal command line. \"-s\" "
                                     "option must be followed by a string, "
                                     "and the string must not begin with "
                                     "'-'.\n");
@@ -371,7 +371,7 @@ main(int argc, char* argv[])
                         report_stems = true;
                         break;
                     default:
-                        fprintf(stdout, "Error. %s is an invalid parameter.\n",
+                        fprintf(stderr, "Error. %s is an invalid parameter.\n",
                                 current_arg);
                         badParam = true;
                         break;
@@ -381,7 +381,7 @@ main(int argc, char* argv[])
                 printVersions();
                 exit(0);
             default:
-                fprintf(stdout, "Error. %s is an invalid parameter.\n",
+                fprintf(stderr, "Error. %s is an invalid parameter.\n",
                         current_arg);
                 badParam = true;
                 break;
@@ -399,12 +399,12 @@ main(int argc, char* argv[])
     }
 
     if (firstFileNameIndex == -1) {
-        fprintf(stdout,
+        fprintf(stderr,
                 "Error. Illegal command line. Must provide bez file name.\n");
         badParam = true;
     }
     if (fontinfo == NULL) {
-        fprintf(stdout,
+        fprintf(stderr,
                 "Error. Illegal command line. Must provide font info.\n");
         badParam = true;
     }
@@ -444,7 +444,7 @@ main(int argc, char* argv[])
                     if (!argumentIsBezData) {
                         writeFileData(bezName, output, fileSuffix);
                     } else {
-                        printf("%s", output);
+                        fprintf(stdout, "%s", output);
                     }
                 }
             }

--- a/libpsautohint/autohintexe.c
+++ b/libpsautohint/autohintexe.c
@@ -118,19 +118,19 @@ static void
 reportCB(char* msg, int level)
 {
     switch (level) {
-        case -1: /* LOGDEBUG */
+        case AC_LogDebug:
             if (debug)
                 fprintf(stderr, "DEBUG: %s\n", msg);
             break;
-        case 0: /* INFO */
+        case AC_LogInfo:
             if (verbose)
                 fprintf(stderr, "INFO: %s\n", msg);
             break;
-        case 1: /* WARNING */
+        case AC_LogWarning:
             if (verbose)
                 fprintf(stderr, "WARNING: %s\n", msg);
             break;
-        case 2: /* LOGERROR */
+        case AC_LogError:
             fprintf(stderr, "ERROR: %s\n", msg);
             break;
         default:

--- a/libpsautohint/include/psautohint.h
+++ b/libpsautohint/include/psautohint.h
@@ -160,6 +160,15 @@ ACLIB_API int AutoHintStringMM(const char** srcbezdata, int nmasters,
  */
 ACLIB_API void AC_initCallGlobals(void);
 
+
+typedef struct ACBuffer ACBuffer;
+
+ACLIB_API ACBuffer* ACBufferNew(size_t size);
+ACLIB_API void ACBufferFree(ACBuffer* buffer);
+ACLIB_API void ACBufferReset(ACBuffer* buffer);
+ACLIB_API void ACBufferWrite(ACBuffer* buffer, char* data, size_t length);
+ACLIB_API void ACBufferRead(ACBuffer* buffer, char** data, size_t* length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libpsautohint/include/psautohint.h
+++ b/libpsautohint/include/psautohint.h
@@ -91,15 +91,20 @@ ACLIB_API void AC_SetReportCB(AC_REPORTFUNCPTR reportCB);
  * If allStems is false, then stems defined by curves are excluded from the
  * reporting.
  *
+ * userData is a pointer provided by the client, and will be passed to report
+ * callback functions.
+ *
  * Note that the callbacks should not dispose of the glyphName memory; that
  * belongs to the AC lib. It should be copied immediately - it may may last
  * past the return of the callback.
  */
-typedef void (*AC_REPORTSTEMPTR)(float top, float bottom, char* glyphName);
+typedef void (*AC_REPORTSTEMPTR)(float top, float bottom, char* glyphName,
+                                 void* userData);
 
 ACLIB_API void AC_SetReportStemsCB(AC_REPORTSTEMPTR hstemCB,
                                    AC_REPORTSTEMPTR vstemCB,
-                                   unsigned int allStems);
+                                   unsigned int allStems,
+                                   void* userData);
 
 /*
  * Function: AC_SetReportZonesCB
@@ -107,14 +112,19 @@ ACLIB_API void AC_SetReportStemsCB(AC_REPORTSTEMPTR hstemCB,
  * If this is called , then the AC lib will write all the alignment zones it
  * encounters.
  *
+ * userData is a pointer provided by the client, and will be passed to report
+ * callback functions.
+ *
  * Note that the callbacks should not dispose of the glyphName memory; that
  * belongs to the AC lib. It should be copied immediately - it may may last
  * past the return of the callback.
  */
-typedef void (*AC_REPORTZONEPTR)(float top, float bottom, char* glyphName);
+typedef void (*AC_REPORTZONEPTR)(float top, float bottom, char* glyphName,
+                                 void* userData);
 
 ACLIB_API void AC_SetReportZonesCB(AC_REPORTZONEPTR charCB,
-                                   AC_REPORTZONEPTR stemCB);
+                                   AC_REPORTZONEPTR stemCB,
+                                   void* userData);
 
 /*
  * Function: AC_SetReportRetryCB
@@ -124,9 +134,9 @@ ACLIB_API void AC_SetReportZonesCB(AC_REPORTZONEPTR charCB,
  *
  * This is to be used when AC_SetReportZonesCB or AC_SetReportStemsCB are used.
  */
-typedef void (*AC_RETRYPTR)(void);
+typedef void (*AC_RETRYPTR)(void* userData);
 
-ACLIB_API void AC_SetReportRetryCB(AC_RETRYPTR retryCB);
+ACLIB_API void AC_SetReportRetryCB(AC_RETRYPTR retryCB, void* userData);
 
 /*
  * Function: AutoHintString

--- a/libpsautohint/include/psautohint.h
+++ b/libpsautohint/include/psautohint.h
@@ -46,6 +46,14 @@ enum
     AC_InvalidParameterError
 };
 
+enum
+{
+    AC_LogDebug = -1,
+    AC_LogInfo,
+    AC_LogWarning,
+    AC_LogError
+};
+
 /*
  * Function: AC_getVersion
  *

--- a/libpsautohint/meson.build
+++ b/libpsautohint/meson.build
@@ -34,6 +34,7 @@ libpsautohint = library(
   'src/basic.h',
   'src/bbox.c',
   'src/bbox.h',
+  'src/buffer.c',
   'src/charpath.c',
   'src/charpath.h',
   'src/charpathpriv.c',

--- a/libpsautohint/src/ac.c
+++ b/libpsautohint/src/ac.c
@@ -42,6 +42,9 @@ AC_REPORTSTEMPTR gAddVStemCB = NULL;
 AC_REPORTZONEPTR gAddGlyphExtremesCB = NULL;
 AC_REPORTZONEPTR gAddStemExtremesCB = NULL;
 AC_RETRYPTR gReportRetryCB = NULL;
+void* gAddStemUserData = NULL;
+void* gAddExtremesUserData = NULL;
+void* gReportRetryUserData = NULL;
 
 #define VMSIZE (1000000)
 static unsigned char *vmfree, *vmlast, vm[VMSIZE];

--- a/libpsautohint/src/ac.h
+++ b/libpsautohint/src/ac.h
@@ -196,9 +196,13 @@ extern AC_REPORTSTEMPTR gAddVStemCB;
 extern AC_REPORTZONEPTR gAddGlyphExtremesCB;
 extern AC_REPORTZONEPTR gAddStemExtremesCB;
 
-void AddStemExtremes(Fixed bot, Fixed top);
-
 extern AC_RETRYPTR gReportRetryCB;
+
+extern void* gAddStemUserData;
+extern void* gAddExtremesUserData;
+extern void* gReportRetryUserData;
+
+void AddStemExtremes(Fixed bot, Fixed top);
 
 #define leftList (gSegLists[0])
 #define rightList (gSegLists[1])

--- a/libpsautohint/src/ac.h
+++ b/libpsautohint/src/ac.h
@@ -165,12 +165,6 @@ typedef struct {
   size_t length;    /* number of the entries */
 } ACFontInfo;
 
-typedef struct {
-  char* data;       /* glyph data held in the buffer */
-  size_t length;    /* actual length of the data */
-  size_t capacity;  /* allocated memory size */
-} ACBuffer;
-
 /* global data */
 
 extern ACBuffer* gBezOutput;

--- a/libpsautohint/src/ac.h
+++ b/libpsautohint/src/ac.h
@@ -260,7 +260,6 @@ int32_t FRnd(int32_t x);
 #define ProdGe0(f0, f1) (!ProdLt0(f0, f1))
 
 #define DEBUG_ROUND(val) { val = ( val >=0 ) ? (2*(val/2)) : (2*((val - 1)/2));}
-#define DEBUG_ROUND4(val) { val = ( val >=0 ) ? (4*(val/4)) : (4*((val - 1)/4));}
 
 #define MAXBUFFLEN 127
 

--- a/libpsautohint/src/ac.h
+++ b/libpsautohint/src/ac.h
@@ -238,8 +238,8 @@ extern char gGlyphName[MAX_GLYPHNAME_LEN];
 #define FixHalf (0x80)
 #define FixQuarter (0x40)
 
-#define FixedPosInf INT32_MAX
-#define FixedNegInf INT32_MIN
+#define FIXED_MAX INT32_MAX
+#define FIXED_MIN INT32_MIN
 #define FixInt(i) (((int32_t)(i)) * FixOne)
 #define FixReal(i) ((int32_t)((i) * (float)FixOne))
 int32_t FRnd(int32_t x);

--- a/libpsautohint/src/acfixed.c
+++ b/libpsautohint/src/acfixed.c
@@ -21,9 +21,9 @@ Fixed
 acpflttofix(float* pf)
 {
     float f = *pf;
-    if (f >= FixedPosInf / FIXEDSCALE)
-        return FixedPosInf;
-    if (f <= FixedNegInf / FIXEDSCALE)
-        return FixedNegInf;
+    if (f >= FIXED_MAX / FIXEDSCALE)
+        return FIXED_MAX;
+    if (f <= FIXED_MIN / FIXEDSCALE)
+        return FIXED_MIN;
     return (Fixed)(f * FIXEDSCALE);
 }

--- a/libpsautohint/src/auto.c
+++ b/libpsautohint/src/auto.c
@@ -779,7 +779,7 @@ CompareValues(HintVal* val1, HintVal* val2, int32_t factor, int32_t ghstshift)
 {
     Fixed v1 = val1->vVal, v2 = val2->vVal, mx;
     mx = v1 > v2 ? v1 : v2;
-    while (mx < FixedPosInf / 2) {
+    while (mx < FIXED_MAX / 2) {
         mx <<= 1;
         v1 <<= 1;
         v2 <<= 1;
@@ -794,10 +794,9 @@ CompareValues(HintVal* val1, HintVal* val2, int32_t factor, int32_t ghstshift)
         (val1->vSpc == 0 && val2->vSpc == 0))
         return v1 > v2;
     if (val1->vSpc > 0)
-        return (v1 < FixedPosInf / factor) ? (v1 * factor > v2)
-                                           : (v1 > v2 / factor);
-    return (v2 < FixedPosInf / factor) ? (v1 > v2 * factor)
-                                       : (v1 / factor > v2);
+        return (v1 < FIXED_MAX / factor) ? (v1 * factor > v2)
+                                         : (v1 > v2 / factor);
+    return (v2 < FIXED_MAX / factor) ? (v1 > v2 * factor) : (v1 / factor > v2);
 }
 
 static void

--- a/libpsautohint/src/auto.c
+++ b/libpsautohint/src/auto.c
@@ -778,11 +778,11 @@ bool
 CompareValues(HintVal* val1, HintVal* val2, int32_t factor, int32_t ghstshift)
 {
     Fixed v1 = val1->vVal, v2 = val2->vVal, mx;
-    mx = v1 > v2 ? v1 : v2;
+    mx = NUMMAX(v1, v2);
     while (mx < FIXED_MAX / 2) {
-        mx <<= 1;
-        v1 <<= 1;
-        v2 <<= 1;
+        mx *= 2;
+        v1 *= 2;
+        v2 *= 2;
     }
     if (ghstshift > 0 && val1->vGhst != val2->vGhst) {
         if (val1->vGhst)

--- a/libpsautohint/src/buffer.c
+++ b/libpsautohint/src/buffer.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014 Adobe Systems Incorporated (http://www.adobe.com/).
+ * All Rights Reserved.
+ *
+ * This software is licensed as OpenSource, under the Apache License, Version
+ * 2.0.
+ * This license is available at: http://opensource.org/licenses/Apache-2.0.
+ */
+
+#include "memory.h"
+#include "psautohint.h"
+
+struct ACBuffer
+{
+    char* data;      /* buffer data, NOT null-terminated */
+    size_t len;      /* actual length of the data */
+    size_t capacity; /* allocated memory size */
+};
+
+ACLIB_API ACBuffer*
+ACBufferNew(size_t size)
+{
+    ACBuffer* buffer;
+
+    if (!size)
+        return NULL;
+
+    buffer = (ACBuffer*)AllocateMem(1, sizeof(ACBuffer), "buffer");
+    buffer->data = AllocateMem(size, 1, "buffer data");
+    buffer->data[0] = '\0';
+    buffer->capacity = size;
+    buffer->len = 0;
+
+    return buffer;
+}
+
+ACLIB_API void
+ACBufferFree(ACBuffer* buffer)
+{
+    if (!buffer)
+        return;
+
+    UnallocateMem(buffer->data);
+    UnallocateMem(buffer);
+}
+
+ACLIB_API void
+ACBufferReset(ACBuffer* buffer)
+{
+    if (!buffer)
+        return;
+    buffer->len = 0;
+}
+
+ACLIB_API void
+ACBufferWrite(ACBuffer* buffer, char* data, size_t length)
+{
+    if (!buffer)
+        return;
+
+    if ((buffer->len + length) >= buffer->capacity) {
+        size_t size = NUMMAX(buffer->capacity * 2, buffer->capacity + length);
+        buffer->data = ReallocateMem(buffer->data, size, "buffer data");
+        buffer->capacity = size;
+    }
+    memcpy(buffer->data + buffer->len, data, length);
+    buffer->len += length;
+}
+
+ACLIB_API void
+ACBufferRead(ACBuffer* buffer, char** data, size_t* length)
+{
+    if (buffer) {
+        *data = buffer->data;
+        *length = buffer->len;
+    } else {
+        *data = NULL;
+        *length = 0;
+    }
+}

--- a/libpsautohint/src/control.c
+++ b/libpsautohint/src/control.c
@@ -818,7 +818,7 @@ AddHintsInnerLoop(const char* srcglyph, bool extrahint)
         /* if we are doing the stem and zones reporting, we need to discard the
          * reported. */
         if (gReportRetryCB != NULL) {
-            gReportRetryCB();
+            gReportRetryCB(gReportRetryUserData);
         }
         if (gPathStart == NULL || gPathStart == gPathEnd) {
             LogMsg(LOGERROR, NONFATALERROR, "No glyph path.");

--- a/libpsautohint/src/fix.c
+++ b/libpsautohint/src/fix.c
@@ -17,7 +17,7 @@ InitFix(int32_t reason)
     switch (reason) {
         case STARTUP:
         case RESTART:
-            bPrev = tPrev = FixedPosInf;
+            bPrev = tPrev = FIXED_MAX;
     }
 }
 

--- a/libpsautohint/src/logging.h
+++ b/libpsautohint/src/logging.h
@@ -18,10 +18,10 @@
 #define FATALERROR 2
 
 /* defines for LogMsg level param */
-#define LOGDEBUG -1
-#define INFO 0
-#define WARNING 1
-#define LOGERROR 2
+#define LOGDEBUG  AC_LogDebug
+#define INFO      AC_LogInfo
+#define WARNING   AC_LogWarning
+#define LOGERROR  AC_LogError
 
 /* maximum message length */
 #define MAXMSGLEN 500

--- a/libpsautohint/src/merge.c
+++ b/libpsautohint/src/merge.c
@@ -115,23 +115,23 @@ PruneOne(HintVal* sLst, bool hFlg, HintVal* sL, int32_t i)
 #define PRNFCTR (3)
 
 #define PruneLt(val, v)                                                        \
-    (((v) < (FixedPosInf / 10) && (val) < (FixedPosInf / PRNFCTR))             \
+    (((v) < (FIXED_MAX / 10) && (val) < (FIXED_MAX / PRNFCTR))                 \
        ? ((val)*PRNFCTR < (v)*10)                                              \
        : ((val) / 10 < (v) / PRNFCTR))
 #define PruneLe(val, v)                                                        \
-    (((val) < (FixedPosInf / PRNFCTR)) ? ((v) <= (val)*PRNFCTR)                \
-                                       : ((v) / PRNFCTR <= (val)))
+    (((val) < (FIXED_MAX / PRNFCTR)) ? ((v) <= (val)*PRNFCTR)                  \
+                                     : ((v) / PRNFCTR <= (val)))
 #define PruneGt(val, v)                                                        \
-    (((val) < (FixedPosInf / PRNFCTR)) ? ((v) > (val)*PRNFCTR)                 \
-                                       : ((v) / PRNFCTR > (val)))
+    (((val) < (FIXED_MAX / PRNFCTR)) ? ((v) > (val)*PRNFCTR)                   \
+                                     : ((v) / PRNFCTR > (val)))
 #define MUCHFCTR (50)
 #define PruneMuchGt(val, v)                                                    \
-    (((val) < (FixedPosInf / MUCHFCTR)) ? ((v) > (val)*MUCHFCTR)               \
-                                        : ((v) / MUCHFCTR > (val)))
+    (((val) < (FIXED_MAX / MUCHFCTR)) ? ((v) > (val)*MUCHFCTR)                 \
+                                      : ((v) / MUCHFCTR > (val)))
 #define VERYMUCHFCTR (100)
 #define PruneVeryMuchGt(val, v)                                                \
-    (((val) < (FixedPosInf / VERYMUCHFCTR)) ? ((v) > (val)*VERYMUCHFCTR)       \
-                                            : ((v) / VERYMUCHFCTR > (val)))
+    (((val) < (FIXED_MAX / VERYMUCHFCTR)) ? ((v) > (val)*VERYMUCHFCTR)         \
+                                          : ((v) / VERYMUCHFCTR > (val)))
 
 /* The changes made here and in PruneHVals are to fix a bug in
  MinisterLight/E where the top left point was not getting hinted. */

--- a/libpsautohint/src/pick.c
+++ b/libpsautohint/src/pick.c
@@ -36,9 +36,8 @@ ConsiderPicking(Fixed bestSpc, Fixed bestVal, HintVal* hintList,
         return true;
     if (LtPruneB(bestVal))
         return false;
-    return (bestVal < FixedPosInf / gPruneC)
-             ? (prevBestVal <= bestVal * gPruneC)
-             : (prevBestVal / gPruneC <= bestVal);
+    return (bestVal < FIXED_MAX / gPruneC) ? (prevBestVal <= bestVal * gPruneC)
+                                           : (prevBestVal / gPruneC <= bestVal);
 }
 
 void

--- a/libpsautohint/src/psautohint.c
+++ b/libpsautohint/src/psautohint.c
@@ -32,11 +32,12 @@ AC_SetReportCB(AC_REPORTFUNCPTR reportCB)
 
 ACLIB_API void
 AC_SetReportStemsCB(AC_REPORTSTEMPTR hstemCB, AC_REPORTSTEMPTR vstemCB,
-                    unsigned int allStems)
+                    unsigned int allStems, void* userData)
 {
     gAllStems = allStems;
     gAddHStemCB = hstemCB;
     gAddVStemCB = vstemCB;
+    gAddStemUserData = userData;
     gDoStems = true;
 
     gAddGlyphExtremesCB = NULL;
@@ -45,10 +46,12 @@ AC_SetReportStemsCB(AC_REPORTSTEMPTR hstemCB, AC_REPORTSTEMPTR vstemCB,
 }
 
 ACLIB_API void
-AC_SetReportZonesCB(AC_REPORTZONEPTR glyphCB, AC_REPORTZONEPTR stemCB)
+AC_SetReportZonesCB(AC_REPORTZONEPTR glyphCB, AC_REPORTZONEPTR stemCB,
+                    void* userData)
 {
     gAddGlyphExtremesCB = glyphCB;
     gAddStemExtremesCB = stemCB;
+    gAddExtremesUserData = userData;
     gDoAligns = true;
 
     gAddHStemCB = NULL;
@@ -57,9 +60,10 @@ AC_SetReportZonesCB(AC_REPORTZONEPTR glyphCB, AC_REPORTZONEPTR stemCB)
 }
 
 ACLIB_API void
-AC_SetReportRetryCB(AC_RETRYPTR retryCB)
+AC_SetReportRetryCB(AC_RETRYPTR retryCB, void* userData)
 {
     gReportRetryCB = retryCB;
+    gReportRetryUserData = userData;
 }
 
 /*
@@ -106,7 +110,7 @@ AutoHintString(const char* srcbezdata, const char* fontinfodata,
         return AC_FatalError;
     } else if (value == 1) {
         /* AutoHint was called successfully */
-        char* data;
+        char *data;
         size_t len;
 
         ACBufferRead(gBezOutput, &data, &len);

--- a/libpsautohint/src/report.c
+++ b/libpsautohint/src/report.c
@@ -169,14 +169,7 @@ ReportRemShortHints(Fixed ex, Fixed ey)
            FixToDbl(-ey));
 }
 
-static void
-PrintDebugVal(Fixed v)
-{
-    if (v >= FixInt(100000))
-        LogMsg(LOGDEBUG, OK, "%d", FTrunc(v));
-    else
-        LogMsg(LOGDEBUG, OK, "%g", FixToDbl(v));
-}
+#define VAL(v) ((v) >= FixInt(100000) ? FTrunc(v) : FixToDbl(v))
 
 static void
 ShwHV(HintVal* val)
@@ -184,29 +177,31 @@ ShwHV(HintVal* val)
     Fixed bot, top;
     bot = -val->vLoc1;
     top = -val->vLoc2;
-    LogMsg(LOGDEBUG, OK, "b %g t %g v ", FixToDbl(bot), FixToDbl(top));
-    PrintDebugVal(val->vVal);
-    LogMsg(LOGDEBUG, OK, " s %g", FixToDbl(val->vSpc));
-    if (val->vGhst)
-        LogMsg(LOGDEBUG, OK, " G");
+    LogMsg(LOGDEBUG, OK, "b %g t %g v %g s %g%s", FixToDbl(bot), FixToDbl(top),
+           VAL(val->vVal), FixToDbl(val->vSpc), val->vGhst ? " G" : "");
 }
 
 void
 ShowHVal(HintVal* val)
 {
-    Fixed l, r;
-    HintSeg* seg;
-    ShwHV(val);
-    seg = val->vSeg1;
-    if (seg == NULL)
+    Fixed l1, l2, r1, r2;
+    Fixed bot, top;
+    HintSeg* seg = val->vSeg1;
+    if (seg == NULL) {
+        ShwHV(val);
         return;
-    l = seg->sMin;
-    r = seg->sMax;
-    LogMsg(LOGDEBUG, OK, " l1 %g r1 %g ", FixToDbl(l), FixToDbl(r));
+    }
+    bot = -val->vLoc1;
+    top = -val->vLoc2;
+    l1 = seg->sMin;
+    r1 = seg->sMax;
     seg = val->vSeg2;
-    l = seg->sMin;
-    r = seg->sMax;
-    LogMsg(LOGDEBUG, OK, " l2 %g r2 %g", FixToDbl(l), FixToDbl(r));
+    l2 = seg->sMin;
+    r2 = seg->sMax;
+    LogMsg(LOGDEBUG, OK, "b %g t %g v %g s %g%s l1 %g r1 %g  l2 %g r2 %g",
+           FixToDbl(bot), FixToDbl(top), VAL(val->vVal), FixToDbl(val->vSpc),
+           val->vGhst ? " G" : "", FixToDbl(l1), FixToDbl(r1), FixToDbl(l2),
+           FixToDbl(r2));
 }
 
 void
@@ -230,27 +225,30 @@ ShwVV(HintVal* val)
     Fixed lft, rht;
     lft = val->vLoc1;
     rht = val->vLoc2;
-    LogMsg(LOGDEBUG, OK, "l %g r %g v ", FixToDbl(lft), FixToDbl(rht));
-    PrintDebugVal(val->vVal);
-    LogMsg(LOGDEBUG, OK, " s %g", FixToDbl(val->vSpc));
+    LogMsg(LOGDEBUG, OK, "l %g r %g v %g s %g", FixToDbl(lft), FixToDbl(rht),
+           VAL(val->vVal), FixToDbl(val->vSpc));
 }
 
 void
 ShowVVal(HintVal* val)
 {
-    Fixed b, t;
-    HintSeg* seg;
-    ShwVV(val);
-    seg = val->vSeg1;
-    if (seg == NULL)
+    Fixed b1, b2, t1, t2;
+    Fixed lft, rht;
+    HintSeg* seg = val->vSeg1;
+    if (seg == NULL) {
+        ShwVV(val);
         return;
-    b = -seg->sMin;
-    t = -seg->sMax;
-    LogMsg(LOGDEBUG, OK, " b1 %g t1 %g ", FixToDbl(b), FixToDbl(t));
+    }
+    lft = val->vLoc1;
+    rht = val->vLoc2;
+    b1 = -seg->sMin;
+    t1 = -seg->sMax;
     seg = val->vSeg2;
-    b = -seg->sMin;
-    t = -seg->sMax;
-    LogMsg(LOGDEBUG, OK, " b2 %g t2 %g", FixToDbl(b), FixToDbl(t));
+    b2 = -seg->sMin;
+    t2 = -seg->sMax;
+    LogMsg(LOGDEBUG, OK, "l %g r %g v %g s %g b1 %g t1 %g  b2 %g t2 %g",
+           FixToDbl(lft), FixToDbl(rht), VAL(val->vVal), FixToDbl(val->vSpc),
+           FixToDbl(b1), FixToDbl(t1), FixToDbl(b2), FixToDbl(t2));
 }
 
 void
@@ -326,17 +324,13 @@ LogHintInfo(HintPoint* pl)
 static void
 LstHVal(HintVal* val)
 {
-    LogMsg(LOGDEBUG, OK, "\t");
     ShowHVal(val);
-    LogMsg(LOGDEBUG, OK, " ");
 }
 
 static void
 LstVVal(HintVal* val)
 {
-    LogMsg(LOGDEBUG, OK, "\t");
     ShowVVal(val);
-    LogMsg(LOGDEBUG, OK, " ");
 }
 
 void
@@ -406,42 +400,34 @@ void
 ReportMergeHVal(Fixed b0, Fixed t0, Fixed b1, Fixed t1, Fixed v0, Fixed s0,
                 Fixed v1, Fixed s1)
 {
-    LogMsg(LOGDEBUG, OK,
-
-           "Replace H hints pair at %g %g by %g %g\n\told value ",
+    LogMsg(LOGDEBUG, OK, "Replace H hints pair at %g %g by %g %g",
            FixToDbl(-b0), FixToDbl(-t0), FixToDbl(-b1), FixToDbl(-t1));
-    PrintDebugVal(v0);
-    LogMsg(LOGDEBUG, OK, " %g new value ", FixToDbl(s0));
-    PrintDebugVal(v1);
-    LogMsg(LOGDEBUG, OK, " %g", FixToDbl(s1));
+    LogMsg(LOGDEBUG, OK, "\told value %g %g new value %g %g", VAL(v0),
+           FixToDbl(s0), VAL(v1), FixToDbl(s1));
 }
 
 void
 ReportMergeVVal(Fixed l0, Fixed r0, Fixed l1, Fixed r1, Fixed v0, Fixed s0,
                 Fixed v1, Fixed s1)
 {
-    LogMsg(LOGDEBUG, OK, "Replace V hints pair at %g %g by %g %g\n\told value ",
-           FixToDbl(l0), FixToDbl(r0), FixToDbl(l1), FixToDbl(r1));
-    PrintDebugVal(v0);
-    LogMsg(LOGDEBUG, OK, " %g new value ", FixToDbl(s0));
-    PrintDebugVal(v1);
-    LogMsg(LOGDEBUG, OK, " %g", FixToDbl(s1));
+    LogMsg(LOGDEBUG, OK, "Replace V hints pair at %g %g by %g %g", FixToDbl(l0),
+           FixToDbl(r0), FixToDbl(l1), FixToDbl(r1));
+    LogMsg(LOGDEBUG, OK, "\told value %g %g new value %g %g", VAL(v0),
+           FixToDbl(s0), VAL(v1), FixToDbl(s1));
 }
 
 void
 ReportPruneHVal(HintVal* val, HintVal* v, int32_t i)
 {
-    LogMsg(LOGDEBUG, OK, "PruneHVal: %d\n\t", i);
+    LogMsg(LOGDEBUG, OK, "PruneHVal: %d", i);
     ShowHVal(val);
-    LogMsg(LOGDEBUG, OK, "\n\t");
     ShowHVal(v);
 }
 
 void
 ReportPruneVVal(HintVal* val, HintVal* v, int32_t i)
 {
-    LogMsg(LOGDEBUG, OK, "PruneVVal: %d\n\t", i);
+    LogMsg(LOGDEBUG, OK, "PruneVVal: %d", i);
     ShowVVal(val);
-    LogMsg(LOGDEBUG, OK, "\n\t");
     ShowVVal(v);
 }

--- a/libpsautohint/src/stemreport.c
+++ b/libpsautohint/src/stemreport.c
@@ -16,7 +16,8 @@ AddVStem(Fixed right, Fixed left, bool curved)
         return;
 
     if (gAddVStemCB)
-        gAddVStemCB(FIXED2FLOAT(right), FIXED2FLOAT(left), gGlyphName);
+        gAddVStemCB(FIXED2FLOAT(right), FIXED2FLOAT(left), gGlyphName,
+                    gAddStemUserData);
 }
 
 void
@@ -26,19 +27,22 @@ AddHStem(Fixed top, Fixed bottom, bool curved)
         return;
 
     if (gAddHStemCB)
-        gAddHStemCB(FIXED2FLOAT(top), FIXED2FLOAT(bottom), gGlyphName);
+        gAddHStemCB(FIXED2FLOAT(top), FIXED2FLOAT(bottom), gGlyphName,
+                    gAddStemUserData);
 }
 
 void
 AddGlyphExtremes(Fixed bot, Fixed top)
 {
     if (gAddGlyphExtremesCB)
-        gAddGlyphExtremesCB(FIXED2FLOAT(top), FIXED2FLOAT(bot), gGlyphName);
+        gAddGlyphExtremesCB(FIXED2FLOAT(top), FIXED2FLOAT(bot), gGlyphName,
+                            gAddExtremesUserData);
 }
 
 void
 AddStemExtremes(Fixed bot, Fixed top)
 {
     if (gAddStemExtremesCB)
-        gAddStemExtremesCB(FIXED2FLOAT(top), FIXED2FLOAT(bot), gGlyphName);
+        gAddStemExtremesCB(FIXED2FLOAT(top), FIXED2FLOAT(bot), gGlyphName,
+                           gAddExtremesUserData);
 }

--- a/libpsautohint/src/write.c
+++ b/libpsautohint/src/write.c
@@ -43,15 +43,7 @@ WriteString(char* str)
         return;
     }
 
-    if ((gBezOutput->length + strlen(str)) >= gBezOutput->capacity) {
-        size_t desiredsize =
-          NUMMAX(gBezOutput->capacity * 2, gBezOutput->capacity + strlen(str));
-        gBezOutput->data =
-          ReallocateMem(gBezOutput->data, desiredsize, "output bez data");
-        gBezOutput->capacity = desiredsize;
-    }
-    strcat(gBezOutput->data, str);
-    gBezOutput->length += strlen(str);
+    ACBufferWrite(gBezOutput, str, strlen(str));
 }
 
 /* Note: The 8 bit fixed fraction cannot support more than 2 decimal places. */

--- a/python/psautohint/__init__.py
+++ b/python/psautohint/__init__.py
@@ -12,6 +12,17 @@ from . import _psautohint
 __version__ = _psautohint.version
 
 
+AUTOHINTEXE = os.path.join(
+    os.path.dirname(__file__),
+    "autohintexe" + (".exe" if sys.platform in ("win32", "cygwin") else "")
+)
+if not os.path.isfile(AUTOHINTEXE) or not os.access(AUTOHINTEXE, os.X_OK):
+    import warnings
+    warnings.warn(
+        "embedded 'autohintexe' executable not found: %r" % AUTOHINTEXE
+    )
+
+
 class FontParseError(Exception):
     pass
 
@@ -69,14 +80,3 @@ def hint_compatible_bez_glyphs(info, glyphs, masters):
                                     tuple(tobytes(m) for m in masters))
 
     return [tounicode(g) for g in hinted]
-
-
-AUTOHINTEXE = os.path.join(
-    os.path.dirname(__file__),
-    "autohintexe" + (".exe" if sys.platform in ("win32", "cygwin") else "")
-)
-if not os.path.isfile(AUTOHINTEXE) or not os.access(AUTOHINTEXE, os.X_OK):
-    import warnings
-    warnings.warn(
-        "embedded 'autohintexe' executable not found: %r" % AUTOHINTEXE
-    )

--- a/python/psautohint/__init__.py
+++ b/python/psautohint/__init__.py
@@ -68,13 +68,18 @@ def get_font_format(font_file_path):
 
 
 def _hint_with_autohintexe(info, glyph, allow_edit, allow_hint_sub,
-                           round_coordinates):
+                           round_coordinates, report_zones,
+                           report_stems, report_all_stems):
     import subprocess
 
     edit = "" if allow_edit else "-e"
     hintsub = "" if allow_hint_sub else "-n"
     decimal = "" if round_coordinates else "-d"
-    cmd = [AUTOHINTEXE, edit, hintsub, decimal, "-D", "-i", info, "-b", glyph]
+    zones = "-ra" if report_zones else ""
+    stems = "-rs" if report_stems else ""
+    allstems = "-a" if report_all_stems else ""
+    cmd = [AUTOHINTEXE, edit, hintsub, decimal, zones, stems, allstems,
+           "-D", "-i", info, "-b", glyph]
     cmd = [a for a in cmd if a]  # Filter out empty args, just in case.
     try:
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
@@ -100,19 +105,31 @@ def _hint_with_autohintexe(info, glyph, allow_edit, allow_hint_sub,
 
 
 def hint_bez_glyph(info, glyph, allow_edit=True, allow_hint_sub=True,
-                   round_coordinates=True, use_autohintexe=False):
+                   round_coordinates=True, report_zones=False,
+                   report_stems=False, report_all_stems=False,
+                   use_autohintexe=False):
     if use_autohintexe:
         hinted = _hint_with_autohintexe(info,
                                         glyph,
                                         allow_edit,
                                         allow_hint_sub,
-                                        round_coordinates)
+                                        round_coordinates,
+                                        report_zones,
+                                        report_stems,
+                                        report_all_stems)
     else:
+        report = 0
+        if report_zones:
+            report = 1
+        elif report_stems:
+            report = 2
         hinted = _psautohint.autohint(tobytes(info),
                                       tobytes(glyph),
                                       allow_edit,
                                       allow_hint_sub,
-                                      round_coordinates)
+                                      round_coordinates,
+                                      report,
+                                      report_all_stems)
 
     return tounicode(hinted)
 

--- a/python/psautohint/__main__.py
+++ b/python/psautohint/__main__.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import sys
+import textwrap
 
 from fontTools.misc.py23 import open
 
@@ -343,10 +344,26 @@ class _CustomHelpFormatter(argparse.RawDescriptionHelpFormatter):
     """
     Adds extra line between options
     """
+    @staticmethod
+    def __add_whitespace(i, i_wtsp, arg):
+        if i == 0:
+            return arg
+        return (" " * i_wtsp) + arg
+
     def _split_lines(self, arg, width):
+        arg_rows = arg.splitlines()
+        for i, line in enumerate(arg_rows):
+            search = re.search('\s*[0-9\-]{0,}\.?\s*', line)
+            if line.strip() is "":
+                arg_rows[i] = " "
+            elif search:
+                line_wtsp = search.end()
+                lines = [self.__add_whitespace(j, line_wtsp, x)
+                         for j, x in enumerate(textwrap.wrap(line, width))]
+                arg_rows[i] = lines
+
         # [''] adds the extra line between args
-        return super(_CustomHelpFormatter,
-                     self)._split_lines(arg, width) + ['']
+        return [item for sublist in arg_rows for item in sublist] + ['']
 
 
 class _AdditionalHelpAction(argparse.Action):

--- a/python/psautohint/__main__.py
+++ b/python/psautohint/__main__.py
@@ -11,7 +11,6 @@ import logging
 import os
 import re
 import subprocess
-import sys
 import textwrap
 
 from fontTools.misc.py23 import open
@@ -731,7 +730,7 @@ def main(args=None):
         if pargs.traceback:
             raise
         logging.error(ex)
-        sys.exit(1)
+        return 1
 
 
 class ReportOptions(ACOptions):
@@ -906,8 +905,9 @@ def stemhist(args=None):
         if pargs.traceback:
             raise
         logging.error(ex)
-        sys.exit(1)
+        return 1
 
 
 if __name__ == '__main__':
+    import sys
     sys.exit(main())

--- a/python/psautohint/_psautohint.c
+++ b/python/psautohint/_psautohint.c
@@ -47,16 +47,16 @@ reportCB(char* msg, int level)
     }
 
     switch (level) {
-        case -1: /* LOGDEBUG */
+        case AC_LogDebug:
             PyObject_CallMethod(logger, "debug", "s", msg);
             break;
-        case 0: /* INFO */
+        case AC_LogInfo:
             PyObject_CallMethod(logger, "info", "s", msg);
             break;
-        case 1: /* WARNING */
+        case AC_LogWarning:
             PyObject_CallMethod(logger, "warning", "s", msg);
             break;
-        case 2: /* LOGERROR */
+        case AC_LogError:
             PyObject_CallMethod(logger, "error", "s", msg);
             break;
         default:

--- a/python/psautohint/_psautohint.c
+++ b/python/psautohint/_psautohint.c
@@ -143,7 +143,7 @@ autohint(PyObject* self, PyObject* args)
 
             if (result == AC_Success) {
                 error = false;
-                outObj = PyBytes_FromString(output);
+                outObj = PyBytes_FromStringAndSize(output, outLen);
             }
 
             MEMFREE(output);
@@ -261,7 +261,8 @@ autohintmm(PyObject* self, PyObject* args)
         if (result == AC_Success) {
             error = false;
             for (i = 0; i < inCount; i++) {
-                PyObject* outObj = PyBytes_FromString(outGlyphs[i]);
+                PyObject* outObj =
+                  PyBytes_FromStringAndSize(outGlyphs[i], outputSizes[i]);
                 PyTuple_SET_ITEM(outSeq, i, outObj);
             }
         }

--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -69,6 +69,7 @@ class ACOptions(object):
         self.writeToDefaultLayer = False
         self.baseMaster = {}
         self.font_format = None
+        self.use_autohintexe = False
 
 
 class ACHintError(Exception):
@@ -341,7 +342,8 @@ def hintFile(options, path, outpath, reference_master):
                 newBezString = hint_bez_glyph(fontInfo, bezString,
                                               options.allowChanges,
                                               not options.noHintSub,
-                                              options.round_coords)
+                                              options.round_coords,
+                                              options.use_autohintexe)
                 options.baseMaster[name] = newBezString
             else:
                 baseFontFileName = os.path.basename(options.reference_font)

--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -69,6 +69,9 @@ class ACOptions(object):
         self.writeToDefaultLayer = False
         self.baseMaster = {}
         self.font_format = None
+        self.report_zones = False
+        self.report_stems = False
+        self.report_all_stems = False
         self.use_autohintexe = False
 
 
@@ -343,6 +346,9 @@ def hintFile(options, path, outpath, reference_master):
                                               options.allowChanges,
                                               not options.noHintSub,
                                               options.round_coords,
+                                              options.report_zones,
+                                              options.report_stems,
+                                              options.report_all_stems,
                                               options.use_autohintexe)
                 options.baseMaster[name] = newBezString
             else:

--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -625,6 +625,8 @@ def hintFile(options, path, outpath, reference_master):
             log.info("No glyphs were hinted.")
     elif reports is not None:
         h_stems, v_stems, top_zones, bot_zones = reports.getReportLists()
+        if outpath is None:
+            outpath = path
         PrintReports(outpath, h_stems, v_stems, top_zones, bot_zones)
 
     if processedGlyphCount != seenGlyphCount:

--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -30,6 +30,7 @@
 
 from __future__ import print_function, absolute_import
 
+import ast
 import logging
 import os
 import re
@@ -107,8 +108,8 @@ class GlyphReports:
         for line in lines:
             tokenList = line.split()
             key = tokenList[0]
-            x = eval(tokenList[3])
-            y = eval(tokenList[5])
+            x = ast.literal_eval(tokenList[3])
+            y = ast.literal_eval(tokenList[5])
             hintpos = "%s %s" % (x, y)
             if key == "charZone":
                 self.charZoneList[hintpos] = (x, y)

--- a/setup.py
+++ b/setup.py
@@ -622,6 +622,7 @@ setup(name="psautohint",
       entry_points={
           'console_scripts': [
               "psautohint = psautohint.__main__:main",
+              "psstemhist = psautohint.__main__:stemhist",
           ],
       },
       setup_requires=["setuptools_scm"],

--- a/setup.py
+++ b/setup.py
@@ -496,6 +496,7 @@ libraries = [
                 "libpsautohint/src/acfixed.c",
                 "libpsautohint/src/auto.c",
                 "libpsautohint/src/bbox.c",
+                "libpsautohint/src/buffer.c",
                 "libpsautohint/src/charpath.c",
                 "libpsautohint/src/charpathpriv.c",
                 "libpsautohint/src/charprop.c",

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -176,16 +176,19 @@ def test_unsupported_format(path):
         autohint([path])
 
 
-@pytest.mark.parametrize("option,exception", [
-    ([], SystemExit),
-    (['--traceback'], FontParseError),
-])
-def test_missing_cff_table(option, exception, tmpdir):
+def test_missing_cff_table1(tmpdir):
     path = "%s/dummy/nocff.otf" % DATA_DIR
     out = str(tmpdir / basename(path)) + ".out"
 
-    with pytest.raises(exception):
-        autohint([path, '-o', out] + option)
+    assert autohint([path, '-o', out]) == 1
+
+
+def test_missing_cff_table2(tmpdir):
+    path = "%s/dummy/nocff.otf" % DATA_DIR
+    out = str(tmpdir / basename(path)) + ".out"
+
+    with pytest.raises(FontParseError):
+        autohint([path, '-o', out, '--traceback'])
 
 
 @pytest.mark.parametrize("option,argument", [

--- a/tests/integration/test_hint.py
+++ b/tests/integration/test_hint.py
@@ -72,6 +72,16 @@ def test_cff(cff, tmpdir):
                    str(tmpdir / basename(out)) + ".xml"])
 
 
+def test_autohintexe(tmpdir):
+    path = "%s/dummy/font.ufo" % DATA_DIR
+    out = str(tmpdir / basename(path)) + ".out"
+    options = Options(path, out)
+    options.use_autohintexe = True
+    hintFiles(options)
+
+    assert differ([path, out])
+
+
 tx_found = False
 try:
     subprocess.check_call(["tx", "-h"])

--- a/tests/integration/test_stemhist.py
+++ b/tests/integration/test_stemhist.py
@@ -32,7 +32,19 @@ class Options(ACOptions):
 # @pytest.mark.parametrize("use_autohintexe", [False, True])
 def test_otf(zones, stems, all_stems, tmpdir, use_autohintexe=True):
     path = "%s/dummy/font.otf" % DATA_DIR
-    out = str(tmpdir / basename(path)) + ".out"
+    out = str(tmpdir / basename(path))
     options = Options(path, out, zones, stems, all_stems)
     options.use_autohintexe = use_autohintexe
+
     hintFiles(options)
+
+    if zones:
+        suffixes = ['.top.txt', '.bot.txt']
+    else:
+        suffixes = ['.hstm.txt', '.vstm.txt']
+
+    for suffix in suffixes:
+        exp_suffix = suffix
+        if all_stems:
+            exp_suffix = '.all' + suffix
+        assert differ([path + exp_suffix, out + suffix, '-l', '1'])

--- a/tests/integration/test_stemhist.py
+++ b/tests/integration/test_stemhist.py
@@ -1,0 +1,38 @@
+from __future__ import print_function, division, absolute_import
+
+from os.path import basename
+import pytest
+
+from psautohint.autohint import ACOptions, hintFiles
+
+from .differ import main as differ
+from . import DATA_DIR
+
+
+class Options(ACOptions):
+    def __init__(self, inpath, outpath, zones, stems, all_stems):
+        super(Options, self).__init__()
+        self.inputPaths = [inpath]
+        self.outputPaths = [outpath]
+        self.logOnly = True
+        self.hintAll = True
+        self.verbose = False
+        self.report_zones = zones
+        self.report_stems = stems
+        self.report_all_stems = all_stems
+
+
+@pytest.mark.parametrize("zones,stems,all_stems", [
+    pytest.param(True, False, False, id="report_zones"),
+    pytest.param(False, True, False, id="report_stems"),
+    pytest.param(False, True, True, id="report_stems,all_stems"),
+])
+# This is is disabled for now as mysterious crashes happen when not using
+# autohintexe.
+# @pytest.mark.parametrize("use_autohintexe", [False, True])
+def test_otf(zones, stems, all_stems, tmpdir, use_autohintexe=True):
+    path = "%s/dummy/font.otf" % DATA_DIR
+    out = str(tmpdir / basename(path)) + ".out"
+    options = Options(path, out, zones, stems, all_stems)
+    options.use_autohintexe = use_autohintexe
+    hintFiles(options)

--- a/tests/unittests/test_hint.py
+++ b/tests/unittests/test_hint.py
@@ -88,7 +88,8 @@ def get_glyph(font, name):
     glob.glob("%s/unhinted/*.[uo][ft][of]" % DATA_DIR),
     glob.glob("%s/hinted/*.[uo][ft][of]" % DATA_DIR),
 ))
-def test_bez(unhinted, hinted):
+@pytest.mark.parametrize("use_autohintexe", [False, True])
+def test_bez(unhinted, hinted, use_autohintexe):
     unhinted_base = os.path.splitext(unhinted)[0]
     hinted_base = os.path.splitext(hinted)[0]
 
@@ -121,5 +122,6 @@ def test_bez(unhinted, hinted):
         hinted_otf_glyph = get_glyph(hinted_otf_font, name)
         assert hinted_otf_glyph == hinted_bez_glyph
 
-        result = hint_bez_glyph(bez_info, bez_glyph)
+        result = hint_bez_glyph(bez_info, bez_glyph,
+                                use_autohintexe=use_autohintexe)
         assert normalize_glyph(result, name) == hinted_bez_glyph


### PR DESCRIPTION
This ports relevant code from AFDKO’s `stemhist` and adds a similar tool. This also allows, again, to use `autohintexe` binary instead of the Python C extension.

The `psstemhist` tool uses `autohintexe` by default since we get mysterious crashes when running the test suite while using C extension for stemhist. I tried to debug these crashes for weeks but no avail, I’m suspecting that something is corrupting the memory and causing subsequent calls to the library to crash, but that is just speculation.