### PR TITLE
Fix specifying glyph ranges to hint/process

### DIFF
--- a/python/psautohint/ufoFont.py
+++ b/python/psautohint/ufoFont.py
@@ -321,6 +321,8 @@ Example from "B" in SourceCodePro-Regular
 """
 
 # UFO names
+PUBLIC_GLYPH_ORDER = "public.glyphOrder"
+
 ADOBE_DOMAIN_PREFIX = "com.adobe.type"
 
 PROCESSED_LAYER_NAME = "AFDKO ProcessedGlyphs"
@@ -578,8 +580,16 @@ class UFOFontData:
         return glyph.width, bez, skip
 
     def getGlyphList(self):
-        glyphset = self._get_glyphset()
-        return sorted(list(glyphset.keys()))
+        glyphOrder = self._reader.readLib().get(PUBLIC_GLYPH_ORDER, [])
+        glyphList = list(self._get_glyphset().keys())
+
+        # Sort the returned glyph list by the glyph order as we depend in the
+        # order for expanding glyph ranges.
+        def key_fn(v):
+            if v in glyphOrder:
+                return glyphOrder.index(v)
+            return len(glyphOrder)
+        return sorted(glyphList, key=key_fn)
 
     @property
     def glyphMap(self):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -274,8 +274,9 @@ def test_invalid_save_path(tmpdir):
 
 @pytest.mark.parametrize("args", [
     pytest.param(['-z'], id="report_zones"),
-    pytest.param([], id="report_stems"),
+    pytest.param([],     id="report_stems"),
     pytest.param(['-a'], id="report_stems,all_stems"),
+    pytest.param(['-g', 'a-z,A-Z,zero-nine'], id="report_stems,glyphs"),
 ])
 def test_stemhist(args, tmpdir):
     path = "%s/dummy/font.otf" % DATA_DIR
@@ -292,4 +293,7 @@ def test_stemhist(args, tmpdir):
         exp_suffix = suffix
         if '-a' in args:
             exp_suffix = '.all' + suffix
+        if '-g' in args:
+            g = args[args.index('-g') + 1]
+            exp_suffix = '.' + g + exp_suffix
         assert differ([path + exp_suffix, out + suffix, '-l', '1'])


### PR DESCRIPTION
We were sorting the glyphs by name and not respecting the glyph order, which broke expanding the ranges. Regression from the ufoLib port.

Fixes https://github.com/adobe-type-tools/psautohint/issues/123