### PR TITLE
Fixes for #122

### DIFF
--- a/libpsautohint/autohintexe.c
+++ b/libpsautohint/autohintexe.c
@@ -79,39 +79,32 @@ printHelp(void)
     fprintf(stdout, "   -v print versions.\n");
 }
 
-#define STR_LEN 200
-#define WRITE_TO_BUFFER(text, a1, a2, a3)                                      \
-    if (userData) {                                                            \
-        char str[STR_LEN];                                                     \
-        ACBuffer* buffer = (ACBuffer*)userData;                                \
-        int len = snprintf(str, STR_LEN, text, a1, (double)a2, (double)a3);    \
-        if (len > 0)                                                           \
-            ACBufferWrite(buffer, str,                                         \
-                          (size_t)(len <= STR_LEN ? len : STR_LEN));           \
-    }
-
 static void
 charZoneCB(float top, float bottom, char* glyphName, void* userData)
 {
-    WRITE_TO_BUFFER("charZone %s top %f bottom %f\n", glyphName, top, bottom);
+    ACBufferWriteF((ACBuffer*)userData, "charZone %s top %f bottom %f\n",
+                   glyphName, (double)top, (double)bottom);
 }
 
 static void
 stemZoneCB(float top, float bottom, char* glyphName, void* userData)
 {
-    WRITE_TO_BUFFER("stemZone %s top %f bottom %f\n", glyphName, top, bottom);
+    ACBufferWriteF((ACBuffer*)userData, "stemZone %s top %f bottom %f\n",
+                   glyphName, (double)top, (double)bottom);
 }
 
 static void
 hstemCB(float top, float bottom, char* glyphName, void* userData)
 {
-    WRITE_TO_BUFFER("HStem %s top %f bottom %f\n", glyphName, top, bottom);
+    ACBufferWriteF((ACBuffer*)userData, "HStem %s top %f bottom %f\n",
+                   glyphName, (double)top, (double)bottom);
 }
 
 static void
 vstemCB(float right, float left, char* glyphName, void* userData)
 {
-    WRITE_TO_BUFFER("VStem %s right %f left %f\n", glyphName, right, left);
+    ACBufferWriteF((ACBuffer*)userData, "VStem %s right %f left %f\n",
+                   glyphName, (double)right, (double)left);
 }
 
 static void

--- a/libpsautohint/include/psautohint.h
+++ b/libpsautohint/include/psautohint.h
@@ -61,6 +61,7 @@ ACLIB_API ACBuffer* ACBufferNew(size_t size);
 ACLIB_API void ACBufferFree(ACBuffer* buffer);
 ACLIB_API void ACBufferReset(ACBuffer* buffer);
 ACLIB_API void ACBufferWrite(ACBuffer* buffer, char* data, size_t length);
+ACLIB_API void ACBufferWriteF(ACBuffer* buffer, char* format, ...);
 ACLIB_API void ACBufferRead(ACBuffer* buffer, char** data, size_t* length);
 
 /*

--- a/libpsautohint/include/psautohint.h
+++ b/libpsautohint/include/psautohint.h
@@ -54,6 +54,15 @@ enum
     AC_LogError
 };
 
+
+typedef struct ACBuffer ACBuffer;
+
+ACLIB_API ACBuffer* ACBufferNew(size_t size);
+ACLIB_API void ACBufferFree(ACBuffer* buffer);
+ACLIB_API void ACBufferReset(ACBuffer* buffer);
+ACLIB_API void ACBufferWrite(ACBuffer* buffer, char* data, size_t length);
+ACLIB_API void ACBufferRead(ACBuffer* buffer, char** data, size_t* length);
+
 /*
  * Function: AC_getVersion
  *
@@ -151,7 +160,7 @@ ACLIB_API void AC_SetReportRetryCB(AC_RETRYPTR retryCB, void* userData);
  * insufficient for the target bezdata, it will be reallocated as needed.
  */
 ACLIB_API int AutoHintString(const char* srcbezdata, const char* fontinfo,
-                             char** dstbezdata, size_t* length, int allowEdit,
+                             ACBuffer* outbuffer, int allowEdit,
                              int allowHintSub, int roundCoords);
 
 /*
@@ -159,8 +168,7 @@ ACLIB_API int AutoHintString(const char* srcbezdata, const char* fontinfo,
  *
  */
 ACLIB_API int AutoHintStringMM(const char** srcbezdata, int nmasters,
-                               const char** masters, char** dstbezdata,
-                               size_t* lengths);
+                               const char** masters, ACBuffer** outbuffers);
 
 /*
  * Function: AC_initCallGlobals
@@ -169,15 +177,6 @@ ACLIB_API int AutoHintStringMM(const char** srcbezdata, int nmasters,
  * between any of the auto-hinting and stem reporting modes while running.
  */
 ACLIB_API void AC_initCallGlobals(void);
-
-
-typedef struct ACBuffer ACBuffer;
-
-ACLIB_API ACBuffer* ACBufferNew(size_t size);
-ACLIB_API void ACBufferFree(ACBuffer* buffer);
-ACLIB_API void ACBufferReset(ACBuffer* buffer);
-ACLIB_API void ACBufferWrite(ACBuffer* buffer, char* data, size_t length);
-ACLIB_API void ACBufferRead(ACBuffer* buffer, char** data, size_t* length);
 
 #ifdef __cplusplus
 }

--- a/libpsautohint/meson.build
+++ b/libpsautohint/meson.build
@@ -1,4 +1,4 @@
-project('psautohint', 'c', version : '1.7.0')
+project('psautohint', 'c', version : '1.7.0', default_options : 'c_std=c99')
 
 pkg = import('pkgconfig')
 cc = meson.get_compiler('c')

--- a/libpsautohint/src/ac.h
+++ b/libpsautohint/src/ac.h
@@ -405,7 +405,6 @@ bool AutoHint(const ACFontInfo* fontinfo, const char* srcbezdata,
               bool extrahint, bool changeGlyph, bool roundCoords);
 
 bool MergeGlyphPaths(const char** srcglyphs, int nmasters,
-                     const char** masters, char** outbuffers,
-                     size_t* outlengths);
+                     const char** masters, ACBuffer** outbuffers);
 
 #endif /* AC_AC_H_ */

--- a/libpsautohint/src/ac.h
+++ b/libpsautohint/src/ac.h
@@ -259,8 +259,6 @@ int32_t FRnd(int32_t x);
 
 #define DEBUG_ROUND(val) { val = ( val >=0 ) ? (2*(val/2)) : (2*((val - 1)/2));}
 
-#define MAXBUFFLEN 127
-
 /* DEBUG_ROUND is used to force calculations to come out the same as the previous version, where coordinates used 7 bits for the Fixed fraction, rather than the current 8 bits. Once I am confident that there are no bugs in the update, I will remove all occurences of this macro, and accept the differences due to more exact division */
 /* procedures */
 

--- a/libpsautohint/src/buffer.c
+++ b/libpsautohint/src/buffer.c
@@ -7,6 +7,9 @@
  * This license is available at: http://opensource.org/licenses/Apache-2.0.
  */
 
+#include <stdarg.h>
+
+#include "logging.h"
 #include "memory.h"
 #include "psautohint.h"
 
@@ -65,6 +68,27 @@ ACBufferWrite(ACBuffer* buffer, char* data, size_t length)
     }
     memcpy(buffer->data + buffer->len, data, length);
     buffer->len += length;
+}
+
+#define STRLEN 500
+ACLIB_API void
+ACBufferWriteF(ACBuffer* buffer, char* format, ...)
+{
+    char outstr[STRLEN];
+    int len;
+    va_list va;
+
+    if (!buffer)
+        return;
+
+    va_start(va, format);
+    len = vsnprintf(outstr, STRLEN, format, va);
+    va_end(va);
+
+    if (len > 0 && len <= STRLEN)
+        ACBufferWrite(buffer, outstr, strlen(outstr));
+    else
+        LogMsg(LOGERROR, FATALERROR, "Failed to write string to ACBuffer.");
 }
 
 ACLIB_API void

--- a/libpsautohint/src/charpath.c
+++ b/libpsautohint/src/charpath.c
@@ -7,8 +7,6 @@
  * This license is available at: http://opensource.org/licenses/Apache-2.0.
  */
 
-#include <stdarg.h>
-
 #include "ac.h"
 #include "bbox.h"
 #include "charpath.h"
@@ -46,27 +44,10 @@ static int16_t GetOperandCount(int16_t);
 static void GetLengthandSubrIx(int16_t, int16_t*, int16_t*);
 
 /* macros */
+#define WriteToBuffer(...) ACBufferWriteF(outbuff, __VA_ARGS__)
 #define WRTNUM(i) WriteToBuffer("%d ", (int)(i))
 #define WRTNUMA(i) WriteToBuffer("%0.2f ", round((double)(i)*100) / 100)
-#define WriteStr(str) WriteToBuffer("%s ", str)
 #define WriteSubr(val) WriteToBuffer("%d subr ", val)
-
-/* Checks if buffer needs to grow before writing out string. */
-/* TODO: port to ACBuffer API */
-static void
-WriteToBuffer(char* format, ...)
-{
-    char outstr[MAXBUFFLEN + 1];
-    int len;
-    va_list va;
-
-    va_start(va, format);
-    len = vsnprintf(outstr, MAXBUFFLEN, format, va);
-    va_end(va);
-
-    if (len > 0)
-        ACBufferWrite(outbuff, outstr, (size_t)NUMMIN(len, MAXBUFFLEN + 1));
-}
 
 static void
 WriteX(Fixed x)
@@ -1618,8 +1599,7 @@ WritePaths(ACBuffer** outBuffers)
 
             WritePathElt(mIx, eltix, op, 0, opcount);
 
-            WriteToBuffer(GetOperator(op));
-            WriteToBuffer("\n");
+            WriteToBuffer("%s\n", GetOperator(op));
         }
         WriteToBuffer("ed\n");
     }
@@ -1713,8 +1693,7 @@ WritePaths(ACBuffer** outBuffers)
                 if (subrIx >= 0 && op != CP)
                     WriteSubr(subrIx);
             } /* end of for opix */
-        WriteStr(GetOperator(op));
-        WriteToBuffer("\n");
+        WriteToBuffer("%s\n", GetOperator(op));
     } /* end of for eltix */
     WriteToBuffer("ed\n");
 }

--- a/libpsautohint/src/logging.h
+++ b/libpsautohint/src/logging.h
@@ -7,6 +7,8 @@
  * This license is available at: http://opensource.org/licenses/Apache-2.0.
  */
 
+#include "psautohint.h"
+
 #include "basic.h"
 
 #ifndef BF_LOGGING_H_

--- a/python/psautohint/_psautohint.c
+++ b/python/psautohint/_psautohint.c
@@ -66,48 +66,38 @@ reportCB(char* msg, int level)
     }
 }
 
-#define STR_LEN 200
-#define WRITE_TO_BUFFER(text, a1, a2, a3)                                      \
-    if (userData) {                                                            \
-        char str[STR_LEN];                                                     \
-        ACBuffer* buffer = (ACBuffer*)userData;                                \
-        int len = snprintf(str, STR_LEN, text, a1, (double)a2, (double)a3);    \
-        if (len > 0)                                                           \
-            ACBufferWrite(buffer, str,                                         \
-                          (size_t)(len <= STR_LEN ? len : STR_LEN));           \
-    }
-
 static void
 charZoneCB(float top, float bottom, char* glyphName, void* userData)
 {
-    WRITE_TO_BUFFER("charZone %s top %f bottom %f\n", glyphName, top, bottom);
+    ACBufferWriteF((ACBuffer*)userData, "charZone %s top %f bottom %f\n",
+                   glyphName, (double)top, (double)bottom);
 }
 
 static void
 stemZoneCB(float top, float bottom, char* glyphName, void* userData)
 {
-    WRITE_TO_BUFFER("stemZone %s top %f bottom %f\n", glyphName, top, bottom);
+    ACBufferWriteF((ACBuffer*)userData, "stemZone %s top %f bottom %f\n",
+                   glyphName, (double)top, (double)bottom);
 }
 
 static void
 hstemCB(float top, float bottom, char* glyphName, void* userData)
 {
-    WRITE_TO_BUFFER("HStem %s top %f bottom %f\n", glyphName, top, bottom);
+    ACBufferWriteF((ACBuffer*)userData, "HStem %s top %f bottom %f\n",
+                   glyphName, (double)top, (double)bottom);
 }
 
 static void
 vstemCB(float right, float left, char* glyphName, void* userData)
 {
-    WRITE_TO_BUFFER("VStem %s right %f left %f\n", glyphName, right, left);
+    ACBufferWriteF((ACBuffer*)userData, "VStem %s right %f left %f\n",
+                   glyphName, (double)right, (double)left);
 }
 
 static void
 reportRetry(void* userData)
 {
-    if (userData) {
-        ACBuffer* buffer = (ACBuffer*)userData;
-        ACBufferReset(buffer);
-    }
+    ACBufferReset((ACBuffer*)userData);
 }
 
 #if PY_MAJOR_VERSION >= 3

--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -658,11 +658,14 @@ def hintFiles(options):
     paths = []
     outpaths = []
 
+    # If there is a reference font, prepend it to font paths.
+    # It must be the first font in the list, code below assumes that.
     if options.reference_font:
         fonts.append(openFile(options.reference_font, options))
         paths.append(options.reference_font)
         outpaths.append(options.reference_font)
 
+    # Open the rest of the fonts and handle output paths.
     for i, path in enumerate(options.inputPaths):
         fonts.append(openFile(path, options))
         paths.append(path)
@@ -675,8 +678,12 @@ def hintFiles(options):
         options.noFlex = True
 
     if options.reference_font:
+        # We are doing compatible, AKA multiple master, hinting.
         log.info("Start time: %s.", time.asctime())
 
+        # Get the glyphs and font info of the reference font, we assume the
+        # fonts have the same glyph set, glyph dict and in general are
+        # compatible. If not bad things will happen.
         glyph_list = get_glyph_list(options, fonts[0], paths[0])
         fontinfo_list = get_fontinfo_list(options, fonts[0], paths[0],
                                           glyph_list)
@@ -687,11 +694,15 @@ def hintFiles(options):
             outpath = outpaths[i]
 
             if i == 0:
+                # This is the reference font, pre-hint it as the rest of the
+                # fonts will copy its hinting.
                 glyphs_list.append(
                     hint_font(options, font, glyph_list, fontinfo_list))
             else:
                 glyphs_list.append(get_bez_glyphs(options, font, glyph_list))
 
+        # Run the compatible hinting, copying the hinting of the reference font
+        # to the rest of the fonts.
         hinted_glyphs_list = hint_compatible_fonts(options, fonts, paths,
                                                    glyph_list,
                                                    glyphs_list, fontinfo_list)
@@ -709,6 +720,7 @@ def hintFiles(options):
 
         log.info("End time: %s.", time.asctime())
     else:
+        # Regular hints, just iterate over the fonts and hint each one.
         for i, font in enumerate(fonts):
             path = paths[i]
             outpath = outpaths[i]

--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -275,7 +275,8 @@ def srtRevVal(t):
 
 
 
-def PrintReports(path, h_stems, v_stems, top_zones, bot_zones):
+def PrintReports(path, reports):
+    h_stems, v_stems, top_zones, bot_zones = reports.getReportLists()
     items = ([h_stems, srtCnt], [v_stems, srtCnt],
              [top_zones, srtRevVal], [bot_zones, srtVal])
     atime = time.asctime()
@@ -720,8 +721,7 @@ def hintFiles(options):
             if options.report_zones or options.report_stems:
                 reports = get_glyph_reports(options, font, glyph_list,
                                             fontinfo_list)
-                h_stems, v_stems, top_zones, bot_zones = reports.getReportLists()
-                PrintReports(outpath, h_stems, v_stems, top_zones, bot_zones)
+                PrintReports(outpath, reports)
             else:
                 hinted = hint_font(options, font, glyph_list, fontinfo_list)
                 if hinted:

--- a/tests/integration/test_mmhint.py
+++ b/tests/integration/test_mmhint.py
@@ -1,8 +1,11 @@
 from __future__ import print_function, division, absolute_import
 
 import glob
+from os.path import basename
 import pytest
 
+from fontTools.misc.xmlWriter import XMLWriter
+from fontTools.ttLib import TTFont
 from psautohint.autohint import ACOptions, ACHintError, hintFiles
 
 from .differ import main as differ
@@ -20,19 +23,43 @@ class Options(ACOptions):
         self.verbose = False
 
 
-@pytest.mark.parametrize("base", glob.glob("%s/*/*Masters" % DATA_DIR))
+@pytest.mark.parametrize("base", glob.glob("%s/*/Masters" % DATA_DIR))
 def test_mmufo(base, tmpdir):
     paths = sorted(glob.glob(base + "/*.ufo"))
     # the reference font is modified in-place, make a temp copy first
     reference = make_temp_copy(tmpdir, paths[0])
     inpaths = paths[1:]
-    outpaths = [str(tmpdir / p) for p in inpaths]
+    outpaths = [str(tmpdir / basename(p)) + ".out" for p in inpaths]
 
     options = Options(reference, inpaths, outpaths)
     hintFiles(options)
 
     for inpath, outpath in zip(inpaths, outpaths):
         assert differ([inpath, outpath])
+
+
+@pytest.mark.parametrize("base", glob.glob("%s/*/OTFMasters" % DATA_DIR))
+def test_mmotf(base, tmpdir):
+    paths = sorted(glob.glob(base + "/*.otf"))
+    # the reference font is modified in-place, make a temp copy first
+    reference = make_temp_copy(tmpdir, paths[0])
+    inpaths = paths[1:]
+    outpaths = [str(tmpdir / basename(p)) + ".out" for p in inpaths]
+
+    options = Options(reference, inpaths, outpaths)
+    hintFiles(options)
+
+    refs = [p + ".ref" for p in paths]
+    for ref, out in zip(refs, [reference] + outpaths):
+        for path in (ref, out):
+            font = TTFont(path)
+            assert "CFF " in font
+            writer = XMLWriter(str(tmpdir / basename(path)) + ".xml")
+            font["CFF "].toXML(writer, font)
+            writer.close()
+
+        assert differ([str(tmpdir / basename(ref)) + ".xml",
+                       str(tmpdir / basename(out)) + ".xml"])
 
 
 def test_incompatible_masters(tmpdir):


### PR DESCRIPTION
1. Rewrite autohint.hintFiles() so that the output of hint_compatible_bez_glyphs() is used for reference master as well.
2. Stop adding short line segments to “zero length closepaths”.