### PR TITLE
Add a logging filter to suppress duplicate messages

### DIFF
--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -631,7 +631,7 @@ def hint_font(options, font, glyph_list, fontinfo_list):
 
         if not ("ry" in new_bez_glyph or "rb" in new_bez_glyph or
                 "rm" in new_bez_glyph or "rv" in new_bez_glyph):
-            log.info("No hints added!")
+            log.info("%s: No hints added!", aliases.get(name, name))
 
         if options.logOnly:
             continue


### PR DESCRIPTION
This restore the functionality that was dropped in c73f66c6defe812469108d05eb70dd1d45a1425e, but in Python side this time and additionally it suppresses any duplicated message not just consecutive ones.

Fixes https://github.com/adobe-type-tools/psautohint/issues/147