### PR TITLE
Fix problem with MM hint lists sorting differently.

### DIFF
--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -278,7 +278,7 @@ class GlyphReports:
                   "Vertical Stem List for %s on %s\n" % (path, atime),
                   "Top Zone List for %s on %s\n" % (path, atime),
                   "Bottom Zone List for %s on %s\n" % (path, atime),
-                 )
+                  )
         headers = ("Count\tWidth\tGlyph List\n",
                    "Count\tWidth\tGlyph List\n",
                    "Count\tTop Zone\tGlyph List\n",
@@ -581,7 +581,8 @@ def hint_compatible_glyphs(options, name, bez_glyphs, masters, fontinfo):
                 else:
                     in_bez = [bez_glyphs[0], bez]
                     in_masters = [masters[0], masters[i + 1]]
-                    out = hint_compatible_bez_glyphs(fontinfo, in_bez, in_masters)
+                    out = hint_compatible_bez_glyphs(fontinfo, in_bez,
+                        in_masters)
                 if i == 0:
                     hinted = out
                 else:

--- a/setup.py
+++ b/setup.py
@@ -633,7 +633,7 @@ setup(name="psautohint",
           "testing": [
               "pytest >= 3.0.0, <4",
               "pytest-cov >= 2.5.1, <3",
-              "pytest-xdist >= 1.22.2, <2",
+              "pytest-xdist >= 1.22.2, <1.28.0",
               "pytest-randomly >= 1.2.3, <2",
           ],
       },


### PR DESCRIPTION
Even though the MM bez files are merge compatible after hinting, the T2 CharStrings built from them may not be compatible. This is because hint pairs in T2 CharStrings must be sorted, and duplicates must be eliminated. The differing values of hint pairs between the MM source fonts may cause them to be sorted and filtered differently. The fix was to define a list of the selected hint pair indices and order with the reference font, and then apply this list in the region fonts.