### PR TITLE
Increase stack buffer size in ACBufferWriteF

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,1 @@
-tox>=2.9.1
+tox==3.9.0 # >3.9.0 depends on more-itertools 7.0.0 which dropped Python 2.7 support

--- a/libpsautohint/src/buffer.c
+++ b/libpsautohint/src/buffer.c
@@ -70,7 +70,7 @@ ACBufferWrite(ACBuffer* buffer, char* data, size_t length)
     buffer->len += length;
 }
 
-#define STRLEN 500
+#define STRLEN 1000
 ACLIB_API void
 ACBufferWriteF(ACBuffer* buffer, char* format, ...)
 {
@@ -85,10 +85,22 @@ ACBufferWriteF(ACBuffer* buffer, char* format, ...)
     len = vsnprintf(outstr, STRLEN, format, va);
     va_end(va);
 
-    if (len > 0 && len <= STRLEN)
-        ACBufferWrite(buffer, outstr, strlen(outstr));
-    else
-        LogMsg(LOGERROR, FATALERROR, "Failed to write string to ACBuffer.");
+    if (len > 0 && len <= STRLEN) {
+        ACBufferWrite(buffer, outstr, len);
+    } else {
+        char* outstr = AllocateMem(1, len + 1, "Temporary buffer");
+
+        va_start(va, format);
+        len = vsnprintf(outstr, len + 1, format, va);
+        va_end(va);
+
+        if (len > 0)
+            ACBufferWrite(buffer, outstr, len);
+        else
+            LogMsg(LOGERROR, FATALERROR, "Failed to write string to ACBuffer.");
+
+        UnallocateMem(outstr);
+    }
 }
 
 ACLIB_API void

--- a/tests/integration/test_hint.py
+++ b/tests/integration/test_hint.py
@@ -343,3 +343,13 @@ def test_layers(tmpdir):
     hintFiles(options)
 
     assert differ([path, out])
+
+
+def test_big_glyph(tmpdir):
+    path = "%s/dummy/big_glyph.ufo" % DATA_DIR
+    out = str(tmpdir / basename(path)) + ".out"
+    options = Options(path, out)
+
+    hintFiles(options)
+
+    assert differ([path, out])


### PR DESCRIPTION
Apparently 500 is too small for some glyphs, so increase it to 1000.
Additionally, fallback to heap allocation when needed.