### PR TITLE
Hashing unnormalized floats

### DIFF
--- a/python/psautohint/__main__.py
+++ b/python/psautohint/__main__.py
@@ -352,7 +352,7 @@ class _CustomHelpFormatter(argparse.RawDescriptionHelpFormatter):
     def _split_lines(self, arg, width):
         arg_rows = arg.splitlines()
         for i, line in enumerate(arg_rows):
-            search = re.search('\s*[0-9\-]{0,}\.?\s*', line)
+            search = re.search(r'\s*[0-9\-]{0,}\.?\s*', line)
             if line.strip() is "":
                 arg_rows[i] = " "
             elif search:

--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -110,14 +110,14 @@ class GlyphReports:
                 # avoid counting duplicates
                 if hintpos not in hstems_pos:
                     count = hstems.get(width, 0)
-                    hstems[width] = count+1
+                    hstems[width] = count + 1
                     hstems_pos[hintpos] = width
             elif key == "VStem":
                 width = x - y
                 # avoid counting duplicates
                 if hintpos not in vstems_pos:
                     count = vstems.get(width, 0)
-                    vstems[width] = count+1
+                    vstems[width] = count + 1
                     vstems_pos[hintpos] = width
             else:
                 raise FontParseError("Found unknown keyword %s in report file "
@@ -177,14 +177,14 @@ class GlyphReports:
                    stem_zone_stems
         {
          'A': [{45.5: 1, 47.0: 2}, {229.0: 1}, {}, {}],
-         'B': [{46.0: 2, 46.5: 2, 47.0: 1}, {94.0: 1, 95.0: 1, 100.0: 1}, {}, {}],
+         'B': [{46.0: 2, 46.5: 2, 47.0: 1}, {94.0: 1, 100.0: 1}, {}, {}],
          'C': [{50.0: 2}, {109.0: 1}, {}, {}],
          'D': [{46.0: 1, 46.5: 2, 47.0: 1}, {95.0: 1, 109.0: 1}, {}, {}],
          'E': [{46.5: 2, 47.0: 1, 50.0: 2, 177.0: 1, 178.0: 1},
                {46.0: 1, 75.5: 2, 95.0: 1}, {}, {}],
          'F': [{46.5: 2, 47.0: 1, 50.0: 1, 177.0: 1},
                {46.0: 1, 60.0: 1, 75.5: 1, 95.0: 1}, {}, {}],
-         'G': [{43.0: 1, 44.5: 1, 50.0: 1, 51.0: 1}, {94.0: 1, 109.0: 1}, {}, {}]
+         'G': [{43.0: 1, 44.5: 1, 50.0: 1}, {94.0: 1, 109.0: 1}, {}, {}]
         }
         """
         h_stem_items_dict = defaultdict(set)

--- a/python/psautohint/otfFont.py
+++ b/python/psautohint/otfFont.py
@@ -306,7 +306,8 @@ class HintMask:
 
     @property
     def num_bits(self):
-        count = sum([bin(mask_byte).count('1') for mask_byte in bytearray(self.mask)])
+        count = sum(
+            [bin(mask_byte).count('1') for mask_byte in bytearray(self.mask)])
         return count
 
 
@@ -436,7 +437,7 @@ def build_hint_order(hints):
     hint_list = list(zip(hints, index_list))
     hint_list.sort()
     new_hints = [hint_list[i] for i in range(1, num_hints)
-                 if hint_list[i][0] != hint_list[i-1][0]]
+                 if hint_list[i][0] != hint_list[i - 1][0]]
     new_hints = [hint_list[0]] + new_hints
     hints, hint_order = list(zip(*new_hints))
     # hints is now a list of hint pairs, sorted by increasing bottom edge.
@@ -785,7 +786,7 @@ def _run_tx(args):
 class FixHintWidthDecompiler(SimpleT2Decompiler):
     # If we are using this class, we know the charstring has hints.
     def __init__(self, localSubrs, globalSubrs, private=None):
-        self.hintMaskBytes = 0 # to silence false Codacy error.
+        self.hintMaskBytes = 0  # to silence false Codacy error.
         SimpleT2Decompiler.__init__(self, localSubrs, globalSubrs, private)
         self.has_explicit_width = None
         self.h_hint_args = self.v_hint_args = None
@@ -1101,7 +1102,7 @@ class CFFFontData:
         prev = hints[0]
         for i in range(2, len(hint_args), 2):
             bottom = hint_args[i] + prev[0] + prev[1]
-            hints.append([bottom, hint_args[i+1]])
+            hints.append([bottom, hint_args[i + 1]])
             prev = hints[-1]
         return hints
 
@@ -1130,9 +1131,9 @@ class CFFFontData:
                 bottom_idx = idx * 2
             else:
                 hint_args = decompiler.v_hint_args
-                bottom_idx = (idx-num_hhint_pairs) * 2
+                bottom_idx = (idx - num_hhint_pairs) * 2
             delta = hint_args[bottom_idx] + hint_args[bottom_idx + 1]
-            del hint_args[bottom_idx:bottom_idx+2]
+            del hint_args[bottom_idx:bottom_idx + 2]
             if len(hint_args) > bottom_idx:
                 hint_args[bottom_idx] += delta
 
@@ -1153,8 +1154,7 @@ class CFFFontData:
 
         # If there were decompiler.v_hint_args, but they have now all been
         # deleted, the first token will still be 'vstem[hm]'. Delete it.
-        if ((not decompiler.v_hint_args)
-                and program[0].startswith('vstem')):
+        if ((not decompiler.v_hint_args) and program[0].startswith('vstem')):
             del program[0]
 
         # Add width and updated hints back.
@@ -1184,7 +1184,7 @@ class CFFFontData:
                            if token == 'hintmask']
             for i, hm in enumerate(mm_hint_info.hint_masks):
                 pos = hm_pos_list[i]
-                program[pos+1] = hm.mask
+                program[pos + 1] = hm.mask
 
         # Now fix the control masks. We will weed out a control mask
         # if it ends up with fewer than 3 hints.
@@ -1203,7 +1203,7 @@ class CFFFontData:
             # Remove all the old cntrmask ops
             num_old_cm = len(cntr_masks)
             idx = program.index('cntrmask')
-            del program[idx:idx + num_old_cm*2]
+            del program[idx:idx + num_old_cm * 2]
             cm_progam = [['cntrmask', cm.mask] for cm in
                          mm_hint_info.new_cntr_masks]
             cm_progam = list(itertools.chain(*cm_progam))

--- a/python/psautohint/ufoFont.py
+++ b/python/psautohint/ufoFont.py
@@ -404,6 +404,8 @@ class UFOFontData:
 
         glyph = BezGlyph(bezData)
         glyphset.readGlyph(name, glyph)
+        if hasattr(glyph, 'width'):
+            glyph.width = norm_float(glyph.width)
         self.newGlyphMap[name] = glyph
 
         # updateFromBez is called only if the glyph has been autohinted which
@@ -802,7 +804,7 @@ class HashPointPen(AbstractPointPen):
 
     def __init__(self, glyph):
         self.glyphset = getattr(glyph, "glyphSet", None)
-        self.width = round(getattr(glyph, "width", 1000), 9)
+        self.width = norm_float(round(getattr(glyph, "width", 1000), 9))
         self.data = ["w%s" % self.width]
 
     def getHash(self):
@@ -823,7 +825,8 @@ class HashPointPen(AbstractPointPen):
             pt_type = ""
         else:
             pt_type = segmentType[0]
-        self.data.append("%s%s%s" % (pt_type, repr(pt[0]), repr(pt[1])))
+        self.data.append("%s%s%s" % (
+            pt_type, repr(norm_float(pt[0])), repr(norm_float(pt[1]))))
 
     def addComponent(self, baseGlyphName, transformation, identifier=None,
                      **kwargs):
@@ -831,7 +834,7 @@ class HashPointPen(AbstractPointPen):
 
         for i, v in enumerate(transformation):
             if transformation[i] != self.DEFAULT_TRANSFORM[i]:
-                self.data.append(str(round(v, 9)))
+                self.data.append(str(norm_float(round(v, 9))))
 
         self.data.append("w%s" % self.width)
         glyph = self.glyphset[baseGlyphName]
@@ -904,6 +907,13 @@ class HintMask:
                     makeHintSet(self.vList, self.vstem3List, isH=False))
 
         return hintset
+
+
+def norm_float(value):
+    """Converts a float (whose decimal part is zero) to integer"""
+    if isinstance(value, float) and value % 1 == 0:
+        return int(value)
+    return value
 
 
 def makeStemHintList(hintsStem3, isH):

--- a/python/psautohint/ufoFont.py
+++ b/python/psautohint/ufoFont.py
@@ -900,11 +900,11 @@ class HintMask:
 
         if len(self.hList) > 0 or len(self.hstem3List):
             hintset[STEMS_NAME].extend(
-                    makeHintSet(self.hList, self.hstem3List, isH=True))
+                makeHintSet(self.hList, self.hstem3List, isH=True))
 
         if len(self.vList) > 0 or len(self.vstem3List):
             hintset[STEMS_NAME].extend(
-                    makeHintSet(self.vList, self.vstem3List, isH=False))
+                makeHintSet(self.vList, self.vstem3List, isH=False))
 
         return hintset
 

--- a/python/psautohint/ufoFont.py
+++ b/python/psautohint/ufoFont.py
@@ -911,7 +911,7 @@ class HintMask:
 
 def norm_float(value):
     """Converts a float (whose decimal part is zero) to integer"""
-    if isinstance(value, float) and value % 1 == 0:
+    if isinstance(value, float) and value.is_integer():
         return int(value)
     return value
 

--- a/python/psautohint/ufoFont.py
+++ b/python/psautohint/ufoFont.py
@@ -926,11 +926,7 @@ def makeStemHintList(hintsStem3, isH):
     posList = [op]
     for stem3 in hintsStem3:
         for pos, width in stem3:
-            if pos % 1 == 0:
-                pos = int(pos)
-            if width % 1 == 0:
-                width = int(width)
-            posList.append("%s %s" % (pos, width))
+            posList.append("%s %s" % (norm_float(pos), norm_float(width)))
     return " ".join(posList)
 
 
@@ -943,16 +939,12 @@ def makeHintList(hints, isH):
         if not hint:
             continue
         pos = hint[0]
-        if pos % 1 == 0:
-            pos = int(pos)
         width = hint[1]
-        if width % 1 == 0:
-            width = int(width)
         if isH:
             op = HSTEM_NAME
         else:
             op = VSTEM_NAME
-        hintset.append("%s %s %s" % (op, pos, width))
+        hintset.append("%s %s %s" % (op, norm_float(pos), norm_float(width)))
     return hintset
 
 
@@ -987,12 +979,7 @@ bezToUFOPoint = {
 
 
 def convertCoords(current_x, current_y):
-    x, y = current_x, current_y
-    if x % 1 == 0:
-        x = int(x)
-    if y % 1 == 0:
-        y = int(y)
-    return x, y
+    return norm_float(current_x), norm_float(current_y)
 
 
 def convertBezToOutline(bezString):

--- a/tests/integration/test_hint.py
+++ b/tests/integration/test_hint.py
@@ -304,6 +304,16 @@ def test_hashmap_new_version(tmpdir, caplog):
         hintFiles(options)
 
 
+def test_hashmap_unnormalized_floats(tmpdir):
+    path = "%s/dummy/hashmap_unnormalized_floats.ufo" % DATA_DIR
+    out = str(tmpdir / basename(path)) + ".out"
+    options = Options(path, out)
+
+    hintFiles(options)
+
+    assert differ([path, out])
+
+
 def test_decimals_ufo(tmpdir):
     path = "%s/dummy/decimals.ufo" % DATA_DIR
     out = str(tmpdir / basename(path)) + ".out"


### PR DESCRIPTION
@khaledhosny the current commits in this PR achieve the opposite of https://github.com/adobe-type-tools/afdko/commit/aff99e04a38e3f8852240c8c46d6179d1f341be9, as we agreed.

However, if you look at the [current hash results](https://github.com/adobe-type-tools/psautohint-testdata/compare/6676a7e0a303e32cf36199be8e386675047a30ab...2dc10194fd88d271538c3b5717acd571adf14bc9#diff-fc17c6b280ff7f55ea51e5787368be8c), there are other values that could also be normalized, like the advance and the outline's points.

I think HashPointPen should normalize all the values. This means that some hashes will not match the ones currently produced by `afdko.ufotools`, but the latter can be updated to stay in sync. I understand that these changes will invalidate some of the hashes in existing fonts, but I'm not concerned about that; my focus in on improving the output of HashPointPen.

What are your thoughts?