### PR TITLE
Use all transformation values when hashing composite glyphs

### DIFF
--- a/python/psautohint/ufoFont.py
+++ b/python/psautohint/ufoFont.py
@@ -800,7 +800,6 @@ class BezPen(BasePen):
 
 
 class HashPointPen(AbstractPointPen):
-    DEFAULT_TRANSFORM = (1, 0, 0, 1, 0, 0)
 
     def __init__(self, glyph):
         self.glyphset = getattr(glyph, "glyphSet", None)
@@ -832,9 +831,8 @@ class HashPointPen(AbstractPointPen):
                      **kwargs):
         self.data.append("base:%s" % baseGlyphName)
 
-        for i, v in enumerate(transformation):
-            if transformation[i] != self.DEFAULT_TRANSFORM[i]:
-                self.data.append(str(norm_float(round(v, 9))))
+        for v in transformation:
+            self.data.append(str(norm_float(round(v, 9))))
 
         self.data.append("w%s" % self.width)
         glyph = self.glyphset[baseGlyphName]

--- a/tests/integration/test_hint.py
+++ b/tests/integration/test_hint.py
@@ -304,6 +304,16 @@ def test_hashmap_new_version(tmpdir, caplog):
         hintFiles(options)
 
 
+def test_hashmap_transform(tmpdir):
+    path = "%s/dummy/hashmap_transform.ufo" % DATA_DIR
+    out = str(tmpdir / basename(path)) + ".out"
+    options = Options(path, out)
+
+    hintFiles(options)
+
+    assert differ([path, out])
+
+
 def test_hashmap_unnormalized_floats(tmpdir):
     path = "%s/dummy/hashmap_unnormalized_floats.ufo" % DATA_DIR
     out = str(tmpdir / basename(path)) + ".out"


### PR DESCRIPTION
Fixes #165 