### PR TITLE
Update fonttools to v3.44.0. Pin lxml to v4.3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-fonttools[ufo,lxml]==3.43.1
+lxml==4.3.5
+fonttools[ufo,lxml]==3.44.0


### PR DESCRIPTION
The latest `lxml` has a regression:
> * LP#1838252: The order of an OrderedDict was lost in 4.4.0 when passing it as attrib mapping during element creation.