### PR TITLE
Update psautohint to use autohint CLI options

### DIFF
--- a/python/psautohint/__main__.py
+++ b/python/psautohint/__main__.py
@@ -499,7 +499,7 @@ def get_options(args):
     parser.add_argument(
         'font_paths',
         metavar='FONT',
-        nargs='+',
+        nargs='*',
         type=_validate_path,
         help='Type1/CFF/OTF/UFO font files'
     )
@@ -690,6 +690,13 @@ def get_options(args):
                         filename=parsed_args.log_path)
     for handler in logging.root.handlers:
         handler.addFilter(DuplicateMessageFilter())
+
+    if not len(parsed_args.font_paths) and len(parsed_args.output_paths):
+        # allow "psautohint -o outputpath inputpath"
+        # see https://github.com/adobe-type-tools/psautohint/issues/129
+        half = len(parsed_args.output_paths)//2
+        parsed_args.font_paths = [
+            parsed_args.output_paths.pop(half) for _ in range(half)]
 
     if (parsed_args.output_paths and
             len(parsed_args.font_paths) != len(parsed_args.output_paths)):

--- a/python/psautohint/__main__.py
+++ b/python/psautohint/__main__.py
@@ -717,7 +717,7 @@ def get_options(args):
     parser.add_argument(
         # -a/--all
         '-all',
-        nargs='*',
+        nargs=0,
         action=_DeprecatedAction,
         ap_action='store_true',
         dest='hint_all_ufo',
@@ -726,7 +726,7 @@ def get_options(args):
     parser.add_argument(
         # -w/--write-to-default-layer
         '-wd',
-        nargs='*',
+        nargs=0,
         action=_DeprecatedAction,
         ap_action='store_true',
         dest='write_to_default_layer',
@@ -760,7 +760,7 @@ def get_options(args):
     report_parser.add_argument(
         # --report-only
         '-logOnly',
-        nargs='*',
+        nargs=0,
         dest='report_only',
         action=_DeprecatedAction,
         ap_action='store_true',
@@ -777,7 +777,7 @@ def get_options(args):
     parser.add_argument(
         # -d/--decimal
         '-decimal',
-        nargs='*',
+        nargs=0,
         dest='decimal',
         action=_DeprecatedAction,
         ap_action='store_true',
@@ -786,7 +786,7 @@ def get_options(args):
     parser.add_argument(
         # --no-flex
         '-nf',
-        nargs='*',
+        nargs=0,
         dest='no_flex',
         action=_DeprecatedAction,
         ap_action='store_true',
@@ -795,7 +795,7 @@ def get_options(args):
     parser.add_argument(
         # --no-hint-sub
         '-ns',
-        nargs='*',
+        nargs=0,
         dest='no_hint_sub',
         action=_DeprecatedAction,
         ap_action='store_true',
@@ -811,7 +811,7 @@ def get_options(args):
     parser.add_argument(
         # --print-dflt-fddict
         '-pfd',
-        nargs='*',
+        nargs=0,
         dest='print_dflt_fddict',
         action=_DeprecatedAction,
         ap_action='store_true',
@@ -820,7 +820,7 @@ def get_options(args):
     parser.add_argument(
         # --print-list-fddict
         '-pfdl',
-        nargs='*',
+        nargs=0,
         dest='print_list_fddict',
         action=_DeprecatedAction,
         ap_action='store_true',

--- a/python/psautohint/__main__.py
+++ b/python/psautohint/__main__.py
@@ -366,6 +366,7 @@ class _AdditionalHelpAction(argparse.Action):
     """
     Based on argparse's _HelpAction and _VersionAction.
     """
+
     def __init__(self,
                  option_strings,
                  addl_help=None,
@@ -391,6 +392,7 @@ class _DeprecatedAction(argparse.Action):
     Custom action to raise a DeprecationWarning when hit. Used for the
     autohint compatibility args/flags.
     """
+
     def __init__(self,
                  option_strings,
                  dest,
@@ -850,7 +852,7 @@ def get_options(args):
             len(parsed_args.output_paths or [])):
         # allow "psautohint -o outputpath inputpath"
         # see https://github.com/adobe-type-tools/psautohint/issues/129
-        half = len(parsed_args.output_paths)//2
+        half = len(parsed_args.output_paths) // 2
         parsed_args.font_paths = [
             parsed_args.output_paths.pop(half) for _ in range(half)]
 

--- a/python/psautohint/__main__.py
+++ b/python/psautohint/__main__.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import subprocess
+import sys
 import textwrap
 
 from . import __version__, get_font_format
@@ -385,6 +386,35 @@ class _AdditionalHelpAction(argparse.Action):
         parser.exit(message=formatter.format_help())
 
 
+class _DeprecatedAction(argparse.Action):
+    """
+    Custom action to raise a DeprecationWarning when hit. Used for the
+    autohint compatibility args/flags.
+    """
+    def __init__(self,
+                 option_strings,
+                 dest,
+                 ap_action=None,
+                 **kwArgs):
+        self._ap_action = ap_action
+        super(_DeprecatedAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            **kwArgs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        autohint_compat_warning = (
+            f"WARNING: option '{option_string}' is supported only for "
+            "compatibility with the old 'autohint' tool and may be removed in "
+            "future versions")
+        print(autohint_compat_warning, file=sys.stderr)
+
+        if self._ap_action == 'store_true':
+            setattr(namespace, self.dest, True)
+        else:
+            setattr(namespace, self.dest, values)
+
+
 class DuplicateMessageFilter(logging.Filter):
     """
     Suppresses any log message that was reported before in the same module and
@@ -496,7 +526,7 @@ def get_options(args):
         formatter_class=_CustomHelpFormatter,
         description=__doc__
     )
-    parser.add_argument(
+    parser_fonts = parser.add_argument(
         'font_paths',
         metavar='FONT',
         nargs='*',
@@ -677,6 +707,131 @@ def get_options(args):
         action='store_true',
         help="show traceback for exceptions.",
     )
+
+    # The following are added for compatibility with autohint. The action,
+    # _DeprecatedAction, will cause a warning message to be displayed when
+    # the option is used. Using help=argparse.SUPPRESS causes them not to be
+    # displayed in the standard help ('psautohint -h/--help').
+    parser.add_argument(
+        # -a/--all
+        '-all',
+        nargs='*',
+        action=_DeprecatedAction,
+        ap_action='store_true',
+        dest='hint_all_ufo',
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        # -w/--write-to-default-layer
+        '-wd',
+        nargs='*',
+        action=_DeprecatedAction,
+        ap_action='store_true',
+        dest='write_to_default_layer',
+        help=argparse.SUPPRESS,
+    )
+    glyphs_parser.add_argument(
+        # --glyphs-file
+        '-gf',
+        dest='glyphs_to_hint_file',
+        action=_DeprecatedAction,
+        type=_validate_path,
+        help=argparse.SUPPRESS,
+    )
+    glyphs_parser.add_argument(
+        # -x/--exclude-glyphs
+        '-xg',
+        dest='glyphs_to_not_hint',
+        action=_DeprecatedAction,
+        type=_split_comma_sequence,
+        default=[],
+        help=argparse.SUPPRESS,
+    )
+    glyphs_parser.add_argument(
+        # --exclude-glyphs-file
+        '-xgf',
+        dest='glyphs_to_not_hint_file',
+        action=_DeprecatedAction,
+        type=_validate_path,
+        help=argparse.SUPPRESS,
+    )
+    report_parser.add_argument(
+        # --report-only
+        '-logOnly',
+        nargs='*',
+        dest='report_only',
+        action=_DeprecatedAction,
+        ap_action='store_true',
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        # --log
+        '-log',
+        dest='log_path',
+        action=_DeprecatedAction,
+        type=_check_save_path,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        # -d/--decimal
+        '-decimal',
+        nargs='*',
+        dest='decimal',
+        action=_DeprecatedAction,
+        ap_action='store_true',
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        # --no-flex
+        '-nf',
+        nargs='*',
+        dest='no_flex',
+        action=_DeprecatedAction,
+        ap_action='store_true',
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        # --no-hint-sub
+        '-ns',
+        nargs='*',
+        dest='no_hint_sub',
+        action=_DeprecatedAction,
+        ap_action='store_true',
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        # --no-zones-stems
+        '-nb',
+        action='store_true',
+        dest='no_zones_stems',
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        # --print-dflt-fddict
+        '-pfd',
+        nargs='*',
+        dest='print_dflt_fddict',
+        action=_DeprecatedAction,
+        ap_action='store_true',
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        # --print-list-fddict
+        '-pfdl',
+        nargs='*',
+        dest='print_list_fddict',
+        action=_DeprecatedAction,
+        ap_action='store_true',
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        # --doc-fddict
+        '-hfd',
+        action=_AdditionalHelpAction,
+        help=argparse.SUPPRESS,
+        addl_help=FDDICT_DOC
+    )
+
     parsed_args = parser.parse_args(args)
 
     if parsed_args.verbose == 0:
@@ -691,12 +846,17 @@ def get_options(args):
     for handler in logging.root.handlers:
         handler.addFilter(DuplicateMessageFilter())
 
-    if not len(parsed_args.font_paths) and len(parsed_args.output_paths):
+    if (not len(parsed_args.font_paths or []) and
+            len(parsed_args.output_paths or [])):
         # allow "psautohint -o outputpath inputpath"
         # see https://github.com/adobe-type-tools/psautohint/issues/129
         half = len(parsed_args.output_paths)//2
         parsed_args.font_paths = [
             parsed_args.output_paths.pop(half) for _ in range(half)]
+
+    if not len(parsed_args.font_paths):
+        parser.error(
+            f"the following arguments are required: {parser_fonts.metavar}")
 
     if (parsed_args.output_paths and
             len(parsed_args.font_paths) != len(parsed_args.output_paths)):
@@ -935,5 +1095,4 @@ def stemhist(args=None):
 
 
 if __name__ == '__main__':
-    import sys
     sys.exit(main())

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -298,14 +298,14 @@ def test_stemhist(args, tmpdir):
 
 
 @pytest.mark.parametrize("path", FONTS)
-def test_outpath_intuitive(path, tmpdir):
+def test_outpath_order(path, tmpdir):
     """ e.g. psautohint -o outfile infile"""
     out = str(tmpdir / basename(path)) + ".out"
 
     autohint(['-o', out, path])
 
 
-def test_multi_intuitive(tmpdir):
+def test_multi_order(tmpdir):
     """ e.g. psautohint -o outfile1 outfile2 infile1 infile2"""
     in1 = "%s/dummy/font.ufo" % DATA_DIR
     in2 = "%s/dummy/big_glyph.ufo" % DATA_DIR
@@ -315,7 +315,7 @@ def test_multi_intuitive(tmpdir):
     autohint(['-o', out1, out2, in1, in2])
 
 
-def test_multi_intuitive_unequal(tmpdir):
+def test_multi_order_unequal(tmpdir):
     """ e.g. psautohint -o outfile1 outfile2 infile"""
     in1 = "%s/dummy/font.ufo" % DATA_DIR
     out1 = str(tmpdir / basename(in1)) + ".out"

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -295,3 +295,31 @@ def test_stemhist(args, tmpdir):
             g = args[args.index('-g') + 1]
             exp_suffix = '.' + g + exp_suffix
         assert differ([path + exp_suffix, out + suffix, '-l', '1'])
+
+
+@pytest.mark.parametrize("path", FONTS)
+def test_outpath_intuitive(path, tmpdir):
+    """ e.g. psautohint -o outfile infile"""
+    out = str(tmpdir / basename(path)) + ".out"
+
+    autohint(['-o', out, path])
+
+
+def test_multi_intuitive(tmpdir):
+    """ e.g. psautohint -o outfile1 outfile2 infile1 infile2"""
+    in1 = "%s/dummy/font.ufo" % DATA_DIR
+    in2 = "%s/dummy/big_glyph.ufo" % DATA_DIR
+    out1 = str(tmpdir / basename(in1)) + ".out"
+    out2 = str(tmpdir / basename(in2)) + ".out"
+
+    autohint(['-o', out1, out2, in1, in2])
+
+
+def test_multi_intuitive_unequal(tmpdir):
+    """ e.g. psautohint -o outfile1 outfile2 infile"""
+    in1 = "%s/dummy/font.ufo" % DATA_DIR
+    out1 = str(tmpdir / basename(in1)) + ".out"
+    out2 = str(tmpdir / basename(in1)) + "X.out"
+
+    with pytest.raises(SystemExit):
+        autohint(['-o', out1, out2, in1])

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -340,6 +340,22 @@ def test_legacy_option(capsys, tmpdir):
     assert expected in captured.err
 
 
+def test_legacy_option_order(capsys, tmpdir):
+    """ Check that boolean legacy options do not consume input path as
+    its args (leading to misleading error)"""
+    path = "%s/dummy/font.ufo" % DATA_DIR
+    out = str(tmpdir / basename(path)) + ".out"
+
+    autohint(['-wd', path, '-o', out])
+    captured = capsys.readouterr()
+    expected = (
+        "WARNING: option '-wd' is supported only for compatibility with "
+        "the old 'autohint' tool and may be removed in future versions")
+
+    assert expected in captured.err
+    assert "the following arguments are required:" not in captured.err
+
+
 def test_lack_of_input_raises(tmpdir):
     with pytest.raises(SystemExit):
         autohint(['--report-only'])

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -323,3 +323,23 @@ def test_multi_intuitive_unequal(tmpdir):
 
     with pytest.raises(SystemExit):
         autohint(['-o', out1, out2, in1])
+
+
+def test_legacy_option(capsys, tmpdir):
+    """ Check that a warning is issued when legacy autohint
+    options are used."""
+    inpath = "%s/dummy/font.ufo" % DATA_DIR
+    outpath = str(tmpdir / basename(inpath)) + ".out"
+
+    autohint([inpath, '-o', outpath, '-logOnly', '-xg', 'fake.txt'])
+    captured = capsys.readouterr()
+    expected = (
+        "WARNING: option '-logOnly' is supported only for compatibility with "
+        "the old 'autohint' tool and may be removed in future versions")
+
+    assert expected in captured.err
+
+
+def test_lack_of_input_raises(tmpdir):
+    with pytest.raises(SystemExit):
+        autohint(['--report-only'])


### PR DESCRIPTION
Use legacy `autohint` CLI flags & fix "intuitive" use of `-o` option (output preceding input).

closes #176 
closes #129 