### PR TITLE
CFF2 VF hinting

### DIFF
--- a/python/psautohint/otfFont.py
+++ b/python/psautohint/otfFont.py
@@ -866,6 +866,7 @@ class CFFFontData:
         self.t2_widths = {}
         self.is_cff2 = False
         self.is_vf = False
+        self.vs_data_models = None
         if font_format == "OTF":
             # It is an OTF font, we can process it directly.
             font = TTFont(path)
@@ -1221,9 +1222,10 @@ class CFFFontData:
                     h_hint_args = program[:idx]
                     v_program = program[idx+1:]
 
-                    for j, token in enumerate(v_program):
-                        if type(token) is str:
-                            if (token[:5] == 'vstem') or token[-4:] == 'mask':
+                    for j, vtoken in enumerate(v_program):
+                        if type(vtoken) is str:
+                            if (vtoken[:5] == 'vstem') or vtoken[-4:] == \
+                                    'mask':
                                 v_hint_args = v_program[:j]
                                 break
                 break
@@ -1433,7 +1435,6 @@ def interpolate_cff2_charstring(charstring, gname, interpolateFromDeltas,
             argi = i - (num_args * numMasters + 1)
             if last_i != argi:
                 new_program.extend(program[last_i:argi])
-                last_i = argi
             end_args = tuplei = argi + num_args
             master_args = []
             while argi < end_args:

--- a/python/psautohint/ufoFont.py
+++ b/python/psautohint/ufoFont.py
@@ -390,13 +390,13 @@ class UFOFontData:
         # We do not yet support reading hints, so read_hints is ignored.
         width, bez, skip = self._get_or_skip_glyph(name, round_coords, doAll)
         if skip:
-            return None, width
+            return None
 
         bezString = "\n".join(bez)
         bezString = "\n".join(["% " + name, "sc", bezString, "ed", ""])
-        return bezString, width
+        return bezString
 
-    def updateFromBez(self, bezData, name, width, mm_hint_info=None):
+    def updateFromBez(self, bezData, name, mm_hint_info=None):
         # For UFO font, we don't use the width parameter:
         # it is carried over from the input glif file.
         layer = None

--- a/python/psautohint/ufoFont.py
+++ b/python/psautohint/ufoFont.py
@@ -382,6 +382,10 @@ class UFOFontData:
     def isCID():
         return False
 
+    @staticmethod
+    def hasFDArray():
+        return False
+
     def convertToBez(self, name, read_hints, round_coords, doAll=False):
         # We do not yet support reading hints, so read_hints is ignored.
         width, bez, skip = self._get_or_skip_glyph(name, round_coords, doAll)


### PR DESCRIPTION
Refactored code to allow sharing paths between hinting source fonts for MM fonts, and hinting a CFF2 variable font. Hinting the master sources for a glyph for the two cases is now identical. The latter differs from the former in that the VF charstring must first be interpolated to a regular T2 charstring for each master source font. After the hinting is done, the T2 charstrings must be merged back together into a single VF charstring.

I also renamed some variables that had different meanings for the same name. For example, 'width' in some contexts contains the advance width for a glyph. In other contexts, it contains the T2 charstring width arg, which is (advance width - CFF nominal width). I renamed all occurrences of 'width' in the latter context to 't2_width_arg'.