### PR TITLE
Add LGTM (Semmle) config

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,10 @@
+extraction:
+  python:
+    python_setup:
+      requirements: "cython>=0.29"
+  cpp:
+    after_prepare:
+    - "pip3 install --upgrade --user cython"
+    - "export PATH=\"$HOME/.local/bin:$PATH\""
+    index:
+      build_command: "python3 setup.py build"


### PR DESCRIPTION
- .lgtm.yml file in root with config that enables C/C++ extraction and build (because default LGTM config fails). This enables the LGTM.com check to correctly extract and analyze the C/C++ portion of the code.