### PR TITLE
Refactored code to allow sharing paths between hinting source fonts f…

### DIFF
--- a/python/psautohint/otfFont.py
+++ b/python/psautohint/otfFont.py
@@ -4,6 +4,7 @@
 Utilities for converting between T2 charstrings and the bez data format.
 """
 
+import copy
 import logging
 import os
 import re
@@ -14,6 +15,13 @@ import itertools
 from fontTools.misc.psCharStrings import (T2OutlineExtractor,
                                           SimpleT2Decompiler)
 from fontTools.ttLib import TTFont, newTable
+from fontTools.misc.fixedTools import otRound
+from fontTools.varLib.varStore import VarStoreInstancer
+from fontTools.varLib.cff import CFF2CharStringMergePen, MergeOutlineExtractor
+# import subset.cff is needed to load the implementation for
+# CFF.desubroutinize: the module adds this class method to the CFF and CFF2
+# classes.
+import fontTools.subset.cff
 
 from . import fdTools, FontParseError
 
@@ -26,6 +34,25 @@ kStemLimit = 96
 
 class SEACError(Exception):
     pass
+
+
+def _add_method(*clazzes):
+    """Returns a decorator function that adds a new method to one or
+    more classes."""
+    def wrapper(method):
+        done = []
+        for clazz in clazzes:
+            if clazz in done:
+                continue  # Support multiple names of a clazz
+            done.append(clazz)
+            assert clazz.__name__ != 'DefaultTable', \
+                'Oops, table class not found.'
+            assert not hasattr(clazz, method.__name__), \
+                "Oops, class '%s' has method '%s'." % (clazz.__name__,
+                                                       method.__name__)
+            setattr(clazz, method.__name__, method)
+        return None
+    return wrapper
 
 
 def hintOn(i, hintMaskBytes):
@@ -233,10 +260,10 @@ def convertT2GlyphToBez(t2CharString, read_hints=True, round_coords=True):
                                  read_hints,
                                  round_coords)
     extractor.execute(t2CharString)
-    width = None
-    if extractor.gotWidth:
-        width = extractor.width - t2CharString.private.nominalWidthX
-    return "".join(extractor.bezProgram), width
+    t2_width_arg = None
+    if extractor.gotWidth and (extractor.width is not None):
+        t2_width_arg = extractor.width - t2CharString.private.nominalWidthX
+    return "".join(extractor.bezProgram), t2_width_arg
 
 
 class HintMask:
@@ -669,97 +696,101 @@ def convertBezToT2(bezString, mm_hint_info=None):
 
     t2Program = []
 
-    if mm_hint_info is None:
-        hhints.sort()
-        vhints.sort()
-    elif mm_hint_info.defined:
-        # Apply hint order from reference font in MM hinting
-        hhints = [hhints[j] for j in mm_hint_info.h_order]
-        vhints = [vhints[j] for j in mm_hint_info.v_order]
-    else:
-        # Define hint order from reference font in MM hinting
-        hhints, mm_hint_info.h_order = build_hint_order(hhints)
-        vhints, mm_hint_info.v_order = build_hint_order(vhints)
+    if hhints or vhints:
+        if mm_hint_info is None:
+            hhints.sort()
+            vhints.sort()
+        elif mm_hint_info.defined:
+            # Apply hint order from reference font in MM hinting
+            hhints = [hhints[j] for j in mm_hint_info.h_order]
+            vhints = [vhints[j] for j in mm_hint_info.v_order]
+        else:
+            # Define hint order from reference font in MM hinting
+            hhints, mm_hint_info.h_order = build_hint_order(hhints)
+            vhints, mm_hint_info.v_order = build_hint_order(vhints)
 
-    num_hhints = len(hhints)
-    num_vhints = len(vhints)
-    hint_limit = int((kStackLimit - 2) / 2)
-    if num_hhints >= hint_limit:
-        hhints = hhints[:hint_limit]
-        num_hhints = hint_limit
-    if num_vhints >= hint_limit:
-        vhints = vhints[:hint_limit]
-        num_vhints = hint_limit
+        num_hhints = len(hhints)
+        num_vhints = len(vhints)
+        hint_limit = int((kStackLimit - 2) / 2)
+        if num_hhints >= hint_limit:
+            hhints = hhints[:hint_limit]
+            num_hhints = hint_limit
+        if num_vhints >= hint_limit:
+            vhints = vhints[:hint_limit]
+            num_vhints = hint_limit
 
-    if mm_hint_info and mm_hint_info.defined:
-        check_hint_pairs(hhints, mm_hint_info)
-        last_idx = len(hhints)
-        check_hint_pairs(vhints, mm_hint_info, last_idx)
+        if mm_hint_info and mm_hint_info.defined:
+            check_hint_pairs(hhints, mm_hint_info)
+            last_idx = len(hhints)
+            check_hint_pairs(vhints, mm_hint_info, last_idx)
 
-    if hhints:
-        t2Program = make_hint_list(hhints, need_hint_masks, is_h=True)
-    if vhints:
-        t2Program += make_hint_list(vhints, need_hint_masks, is_h=False)
+        if hhints:
+            t2Program = make_hint_list(hhints, need_hint_masks, is_h=True)
+        if vhints:
+            t2Program += make_hint_list(vhints, need_hint_masks, is_h=False)
 
-    cntrmask_progam = None
-    if mm_hint_info is None:
-        if v_stem3_list or h_stem3_list:
-            counter_mask_list = build_counter_mask_list(h_stem3_list,
-                                                        v_stem3_list)
-            cntrmask_progam = [['cntrmask', cMask.maskByte(hhints, vhints)] for
+        cntrmask_progam = None
+        if mm_hint_info is None:
+            if v_stem3_list or h_stem3_list:
+                counter_mask_list = build_counter_mask_list(h_stem3_list,
+                                                            v_stem3_list)
+                cntrmask_progam = [['cntrmask', cMask.maskByte(hhints,
+                                                               vhints)] for
+                                   cMask in counter_mask_list]
+        elif (not mm_hint_info.defined):
+            if v_stem3_list or h_stem3_list:
+                # this is the reference font - we need to build the list.
+                counter_mask_list = build_counter_mask_list(h_stem3_list,
+                                                            v_stem3_list)
+                cntrmask_progam = [['cntrmask', cMask.maskByte(hhints,
+                                                               vhints)] for
+                                   cMask in counter_mask_list]
+                mm_hint_info.cntr_masks = counter_mask_list
+        else:
+            # This is a region font - we need to used the reference font list.
+            counter_mask_list = mm_hint_info.cntr_masks
+            cntrmask_progam = [['cntrmask', cMask.mask] for
                                cMask in counter_mask_list]
-    elif (not mm_hint_info.defined):
-        if v_stem3_list or h_stem3_list:
-            # this is the reference font - we need to build the list.
-            counter_mask_list = build_counter_mask_list(h_stem3_list,
-                                                        v_stem3_list)
-            cntrmask_progam = [['cntrmask', cMask.maskByte(hhints, vhints)] for
-                               cMask in counter_mask_list]
-            mm_hint_info.cntr_masks = counter_mask_list
-    else:
-        # This is a region font - we need to used the reference font list.
-        counter_mask_list = mm_hint_info.cntr_masks
-        cntrmask_progam = [['cntrmask', cMask.mask] for
-                           cMask in counter_mask_list]
 
-    if cntrmask_progam:
-        cntrmask_progam = itertools.chain(*cntrmask_progam)
-        t2Program.extend(cntrmask_progam)
+        if cntrmask_progam:
+            cntrmask_progam = itertools.chain(*cntrmask_progam)
+            t2Program.extend(cntrmask_progam)
 
-    if need_hint_masks:
-        # If there is not a hintsub before any drawing operators, then
-        # add an initial first hint mask to the t2Program.
-        if (mm_hint_info is None) or (not mm_hint_info.defined):
-            # a single font and a reference font for mm hinting are
-            # processed the same way
-            if hintMaskList[1].listPos != 0:
-                hBytes = hintMaskList[0].maskByte(hhints, vhints)
-                t2Program.extend(["hintmask", hBytes])
-                if in_mm_hints:
-                    mm_hint_info.hint_masks.append(hintMaskList[0])
+        if need_hint_masks:
+            # If there is not a hintsub before any drawing operators, then
+            # add an initial first hint mask to the t2Program.
+            if (mm_hint_info is None) or (not mm_hint_info.defined):
+                # a single font and a reference font for mm hinting are
+                # processed the same way
+                if hintMaskList[1].listPos != 0:
+                    hBytes = hintMaskList[0].maskByte(hhints, vhints)
+                    t2Program.extend(["hintmask", hBytes])
+                    if in_mm_hints:
+                        mm_hint_info.hint_masks.append(hintMaskList[0])
 
-            # Convert the rest of the hint masks
-            # to a hintmask op and hintmask bytes.
-            for hint_mask in hintMaskList[1:]:
-                pos = hint_mask.listPos
-                hBytes = hint_mask.maskByte(hhints, vhints)
-                t2List[pos] = [["hintmask"], hBytes]
-                if in_mm_hints:
-                    mm_hint_info.hint_masks.append(hint_mask)
-        elif (mm_hint_info is not None):
-            # This is a MM region font: apply hint masks from reference font.
-            try:
-                hm0_mask = mm_hint_info.hint_masks[0].mask
-            except IndexError:
-                import pdb
-                pdb.set_trace()
-            if isinstance(t2List[0][0], HintMask):
-                t2List[0] = [["hintmask"], hm0_mask]
-            else:
-                t2Program.extend(["hintmask", hm0_mask])
+                # Convert the rest of the hint masks
+                # to a hintmask op and hintmask bytes.
+                for hint_mask in hintMaskList[1:]:
+                    pos = hint_mask.listPos
+                    hBytes = hint_mask.maskByte(hhints, vhints)
+                    t2List[pos] = [["hintmask"], hBytes]
+                    if in_mm_hints:
+                        mm_hint_info.hint_masks.append(hint_mask)
+            elif (mm_hint_info is not None):
+                # This is a MM region font:
+                # apply hint masks from reference font.
+                try:
+                    hm0_mask = mm_hint_info.hint_masks[0].mask
+                except IndexError:
+                    import pdb
+                    pdb.set_trace()
+                if isinstance(t2List[0][0], HintMask):
+                    t2List[0] = [["hintmask"], hm0_mask]
+                else:
+                    t2Program.extend(["hintmask", hm0_mask])
 
-            for hm in mm_hint_info.hint_masks[1:]:
-                t2List[hm.listPos] = [["hintmask"], hm.mask]
+                for hm in mm_hint_info.hint_masks[1:]:
+                    t2List[hm.listPos] = [["hintmask"], hm.mask]
 
     for entry in t2List:
         try:
@@ -832,14 +863,23 @@ class CFFFontData:
         self.inputPath = path
         self.font_format = font_format
         self.mm_hint_info_dict = {}
-
+        self.t2_widths = {}
+        self.is_cff2 = False
+        self.is_vf = False
+        self.vs_data_models = None
         if font_format == "OTF":
             # It is an OTF font, we can process it directly.
             font = TTFont(path)
-            if "CFF " not in font:
+            if "CFF "in font:
+                cff_format = "CFF "
+            elif "CFF2" in font:
+                cff_format = "CFF2"
+                self.is_cff2 = True
+            else:
                 raise FontParseError("OTF font has no CFF table <%s>." % path)
         else:
             # Else, package it in an OTF font.
+            cff_format = "CFF "
             if font_format == "CFF":
                 with open(path, "rb") as fp:
                     data = fp.read()
@@ -858,25 +898,55 @@ class CFFFontData:
             font['CFF '].decompile(data, font)
 
         self.ttFont = font
-        self.cffTable = font["CFF "]
+        self.cffTable = font[cff_format]
 
         # for identifier in glyph-list:
         # Get charstring.
         self.topDict = self.cffTable.cff.topDictIndex[0]
         self.charStrings = self.topDict.CharStrings
+        if 'fvar' in self.ttFont:
+            self.is_vf = True
+            fvar = self.ttFont['fvar']
+            CFF2 = self.cffTable
+            CFF2.desubroutinize()
+            topDict = CFF2.cff.topDictIndex[0]
+            self.temp_cs = copy.deepcopy(self.charStrings['.notdef'])
+            self.vs_data_models = self.get_vs_data_models(topDict,
+                                                          fvar)
 
     def getGlyphList(self):
         return self.ttFont.getGlyphOrder()
 
     def getPSName(self):
-        return self.cffTable.cff.fontNames[0]
+        if self.is_cff2 and 'name' in self.ttFont:
+            psName = next((name_rec.string for name_rec in self.ttFont[
+                'name'].names if (name_rec.nameID == 6) and (
+                    name_rec.platformID == 3)))
+            psName = psName.decode('utf-16be')
+        else:
+            psName = self.cffTable.cff.fontNames[0]
+        return psName
+
+    def get_min_max(self, pTopDict, upm):
+        if self.is_cff2 and 'hhea' in self.ttFont:
+            font_max = self.ttFont['hhea'].ascent
+            font_min = self.ttFont['hhea'].descent
+        elif hasattr(pTopDict, 'FontBBox'):
+            font_max = pTopDict.FontBBox[3]
+            font_min = pTopDict.FontBBox[1]
+        else:
+            font_max = upm * 1.25
+            font_min = -upm * 0.25
+        alignment_min = min(-upm * 0.25, font_min)
+        alignment_max = max(upm * 1.25, font_max)
+        return alignment_min, alignment_max
 
     def convertToBez(self, glyphName, read_hints, round_coords, doAll=False):
         t2Wdth = None
         t2CharString = self.charStrings[glyphName]
         try:
-            bezString, t2Wdth = convertT2GlyphToBez(t2CharString, read_hints,
-                                                    round_coords)
+            bezString, t2Wdth = convertT2GlyphToBez(t2CharString,
+                                                    read_hints, round_coords)
             # Note: the glyph name is important, as it is used by autohintexe
             # for various heuristics, including [hv]stem3 derivation.
             bezString = "% " + glyphName + "\n" + bezString
@@ -884,12 +954,22 @@ class CFFFontData:
             log.warning("Skipping %s: can't process SEAC composite glyphs.",
                         glyphName)
             bezString = None
-        return bezString, t2Wdth
+        self.t2_widths[glyphName] = t2Wdth
+        return bezString
 
-    def updateFromBez(self, bezData, glyphName, width, mm_hint_info=None):
-        t2Program = [width] + convertBezToT2(bezData, mm_hint_info)
-        t2CharString = self.charStrings[glyphName]
-        t2CharString.program = t2Program
+    def updateFromBez(self, bezData, glyphName, mm_hint_info=None):
+        t2Program = convertBezToT2(bezData, mm_hint_info)
+        if not self.is_cff2:
+            t2_width_arg = self.t2_widths[glyphName]
+            if t2_width_arg is not None:
+                t2Program = [t2_width_arg] + t2Program
+        if self.vs_data_models is not None:
+            # It is a variable font. Accumulate the charstrings.
+            self.glyph_programs.append(t2Program)
+        else:
+            # This is an MM source font. Update the font's charstring directly.
+            t2CharString = self.charStrings[glyphName]
+            t2CharString.program = t2Program
 
     def save(self, path):
         if path is None:
@@ -922,6 +1002,16 @@ class CFFFontData:
     def isCID(self):
         return hasattr(self.topDict, "FDSelect")
 
+    def hasFDArray(self):
+        return self.is_cff2 or hasattr(self.topDict, "FDSelect")
+
+    def flattenBlends(self, blendList):
+        if type(blendList[0]) is list:
+            flatList = [blendList[i][0] for i in range(len(blendList))]
+        else:
+            flatList = blendList
+        return flatList
+
     def getFontInfo(self, allow_no_blues, noFlex,
                     vCounterGlyphs, hCounterGlyphs, fdIndex=0):
         # The psautohint library needs the global font hint zones
@@ -948,16 +1038,15 @@ class CFFFontData:
 
         fdDict.FontName = getattr(pTopDict, "FontName", self.getPSName())
 
-        low = min(-upm * 0.25, pTopDict.FontBBox[1] - 200)
-        high = max(upm * 1.25, pTopDict.FontBBox[3] + 200)
-        # Make a set of inactive alignment zones: zones outside of the
-        # font BBox so as not to affect hinting. Used when source font has
-        # no BlueValues or has invalid BlueValues. Some fonts have bad BBox
-        # values, so I don't let this be smaller than -upm*0.25, upm*1.25.
-        inactiveAlignmentValues = [low, low, high, high]
         blueValues = getattr(privateDict, "BlueValues", [])[:]
         numBlueValues = len(blueValues)
         if numBlueValues < 4:
+            low, high = self.get_min_max(pTopDict, upm)
+            # Make a set of inactive alignment zones: zones outside of the
+            # font BBox so as not to affect hinting. Used when source font has
+            # no BlueValues or has invalid BlueValues. Some fonts have bad BBox
+            # values, so I don't let this be smaller than -upm*0.25, upm*1.25.
+            inactiveAlignmentValues = [low, low, high, high]
             if allow_no_blues:
                 blueValues = inactiveAlignmentValues
                 numBlueValues = len(blueValues)
@@ -970,6 +1059,7 @@ class CFFFontData:
         # The first pair only is a bottom zone, where the first value is the
         # overshoot position. The rest are top zones, and second value of the
         # pair is the overshoot position.
+        blueValues = self.flattenBlends(blueValues)
         blueValues[0] = blueValues[0] - blueValues[1]
         for i in range(3, numBlueValues, 2):
             blueValues[i] = blueValues[i] - blueValues[i - 1]
@@ -988,6 +1078,7 @@ class CFFFontData:
             numBlueValues = len(privateDict.OtherBlues)
             blueValues = privateDict.OtherBlues[:]
             blueValues.sort()
+            blueValues = self.flattenBlends(blueValues)
             for i in range(0, numBlueValues, 2):
                 blueValues[i] = blueValues[i] - blueValues[i + 1]
             blueValues = [str(v) for v in blueValues]
@@ -1011,6 +1102,7 @@ class CFFFontData:
             else:
                 raise FontParseError("Font has neither StemSnapV nor StdVW!")
         vstems.sort()
+        vstems = self.flattenBlends(vstems)
         if (len(vstems) == 0) or ((len(vstems) == 1) and (vstems[0] < 1)):
             vstems = [upm]  # dummy value that will allow PyAC to run
             log.warning("There is no value or 0 value for DominantV.")
@@ -1029,6 +1121,7 @@ class CFFFontData:
             else:
                 raise FontParseError("Font has neither StemSnapH nor StdHW!")
         hstems.sort()
+        hstems = self.flattenBlends(hstems)
         if (len(hstems) == 0) or ((len(hstems) == 1) and (hstems[0] < 1)):
             hstems = [upm]  # dummy value that will allow PyAC to run
             log.warning("There is no value or 0 value for DominantH.")
@@ -1053,7 +1146,11 @@ class CFFFontData:
 
     def getfdIndex(self, name):
         gid = self.ttFont.getGlyphID(name)
-        return self.topDict.FDSelect[gid]
+        if hasattr(self.topDict, "FDSelect"):
+            fdIndex = self.topDict.FDSelect[gid]
+        else:
+            fdIndex = 0
+        return fdIndex
 
     def getfdInfo(self, allow_no_blues, noFlex, vCounterGlyphs, hCounterGlyphs,
                   glyphList, fdIndex=0):
@@ -1103,31 +1200,52 @@ class CFFFontData:
             prev = hints[-1]
         return hints
 
-    def fix_glyph_hints(self, glyph_name, mm_hint_info, is_reference_font):
-        # 1. Delete any bad hints.
-        # 2. If reference font, recalculate the hint mask byte strings
-        # 3. Replace hint masks.
-        # 3. Fix cntr masks.
-        try:
-            t2CharString = self.charStrings[glyph_name]
-        except KeyError:
-            return  # Happens with sparse source fonts - just skip the glyph.
-        subrs = getattr(t2CharString.private, "Subrs", [])
-        decompiler = FixHintWidthDecompiler(subrs, t2CharString.globalSubrs,
-                                            t2CharString.private)
-        decompiler.execute(t2CharString)
-        program = t2CharString.program
-        num_hhint_pairs = len(decompiler.h_hint_args) // 2
+    @staticmethod
+    def extract_hint_args(program):
+        width = None
+        h_hint_args = []
+        v_hint_args = []
+        for i, token in enumerate(program):
+            if type(token) is str:
+                if i % 2 != 0:
+                    width = program[0]
+                    del program[0]
+                    idx = i - 1
+                else:
+                    idx = i
+
+                if (token[:4] == 'vstem') or token[-3:] == 'mask':
+                    h_hint_args = []
+                    v_hint_args = program[:idx]
+
+                elif token[:5] == 'hstem':
+                    h_hint_args = program[:idx]
+                    v_program = program[idx+1:]
+
+                    for j, vtoken in enumerate(v_program):
+                        if type(vtoken) is str:
+                            if (vtoken[:5] == 'vstem') or vtoken[-4:] == \
+                                    'mask':
+                                v_hint_args = v_program[:j]
+                                break
+                break
+
+        return width, h_hint_args, v_hint_args
+
+    def fix_t2_program_hints(self, program, mm_hint_info, is_reference_font):
+
+        width_arg, h_hint_args, v_hint_args = self.extract_hint_args(program)
 
         # 1. Build list of good [vh]hints.
         bad_hint_idxs = list(mm_hint_info.bad_hint_idxs)
         bad_hint_idxs.sort()
+        num_hhint_pairs = len(h_hint_args) // 2
         for idx in reversed(bad_hint_idxs):
             if idx < num_hhint_pairs:
-                hint_args = decompiler.h_hint_args
+                hint_args = h_hint_args
                 bottom_idx = idx * 2
             else:
-                hint_args = decompiler.v_hint_args
+                hint_args = v_hint_args
                 bottom_idx = (idx - num_hhint_pairs) * 2
             delta = hint_args[bottom_idx] + hint_args[bottom_idx + 1]
             del hint_args[bottom_idx:bottom_idx + 2]
@@ -1149,29 +1267,29 @@ class CFFFontData:
         if last_hint_idx is not None:
             del program[:last_hint_idx]
 
-        # If there were decompiler.v_hint_args, but they have now all been
+        # If there were v_hint_args, but they have now all been
         # deleted, the first token will still be 'vstem[hm]'. Delete it.
-        if ((not decompiler.v_hint_args) and program[0].startswith('vstem')):
+        if ((not v_hint_args) and program[0].startswith('vstem')):
             del program[0]
 
         # Add width and updated hints back.
-        if (decompiler.has_explicit_width):
-            hint_program = [decompiler.width_arg]
+        if width_arg is not None:
+            hint_program = [width_arg]
         else:
             hint_program = []
-        if decompiler.h_hint_args:
+        if h_hint_args:
             op_hstem = 'hstemhm' if mm_hint_info.hint_masks else 'hstem'
-            hint_program.extend(decompiler.h_hint_args)
+            hint_program.extend(h_hint_args)
             hint_program.append(op_hstem)
-        if decompiler.v_hint_args:
-            hint_program.extend(decompiler.v_hint_args)
+        if v_hint_args:
+            hint_program.extend(v_hint_args)
             # Don't need to append op_vstem, as this is still in hint_program.
             program = hint_program + program
 
         # Re-calculate the hint masks.
         if is_reference_font:
-            hhints = self.args_to_hints(decompiler.h_hint_args)
-            vhints = self.args_to_hints(decompiler.v_hint_args)
+            hhints = self.args_to_hints(h_hint_args)
+            vhints = self.args_to_hints(v_hint_args)
             for hm in mm_hint_info.hint_masks:
                 hm.maskByte(hhints, vhints)
 
@@ -1205,5 +1323,196 @@ class CFFFontData:
                          mm_hint_info.new_cntr_masks]
             cm_progam = list(itertools.chain(*cm_progam))
             program[idx:idx] = cm_progam
+        return program
 
-        t2CharString.program = program
+    def fix_glyph_hints(self, glyph_name, mm_hint_info,
+                        is_reference_font=None):
+        # 1. Delete any bad hints.
+        # 2. If reference font, recalculate the hint mask byte strings
+        # 3. Replace hint masks.
+        # 3. Fix cntr masks.
+        if self.is_vf:
+            # We get called once, and fix all the charstring programs.
+            for i, t2_program in enumerate(self.glyph_programs):
+                self.glyph_programs[i] = self.fix_t2_program_hints(
+                    t2_program, mm_hint_info, is_reference_font=(i == 0))
+        else:
+            # we are called for each font in turn
+            try:
+                t2CharString = self.charStrings[glyph_name]
+            except KeyError:
+                return  # Happens with sparse sources - just skip the glyph.
+
+            program = self.fix_t2_program_hints(t2CharString.program,
+                                                mm_hint_info,
+                                                is_reference_font)
+            t2CharString.program = program
+
+    def get_vf_bez_glyphs(self, glyph_name):
+
+        charstring = self.charStrings[glyph_name]
+        if 'fvar' in self.ttFont:
+            # have not yet collected VF global data.
+            self.is_vf = True
+            fvar = self.ttFont['fvar']
+            CFF2 = self.cffTable
+            CFF2.desubroutinize()
+            topDict = CFF2.cff.topDictIndex[0]
+            # We need a new charstring object into which we can save the
+            # hinted CFF2 program data. Copying an existing charstring is a
+            # little easier than creating a new one and making sure that all
+            # properties are set correctly.
+            self.temp_cs = copy.deepcopy(self.charStrings['.notdef'])
+            self.vs_data_models = self.get_vs_data_models(topDict,
+                                                          fvar)
+
+        if 'vsindex' in charstring.program:
+            op_index = charstring.program.index('vsindex')
+            vsindex = charstring.program[op_index - 1]
+        else:
+            vsindex = 0
+        self.vsindex = vsindex
+        self.glyph_programs = []
+        vs_data_model = self.vs_data_model = self.vs_data_models[vsindex]
+
+        bez_list = []
+        for vsi in vs_data_model.master_vsi_list:
+            t2_program = interpolate_cff2_charstring(charstring, glyph_name,
+                                                     vsi.interpolateFromDeltas,
+                                                     vsindex)
+            self.temp_cs.program = t2_program
+            bezString, _ = convertT2GlyphToBez(self.temp_cs, True, True)
+            #  DBG Adding glyph name is useful only for debugging.
+            bezString = "% {}\n".format(glyph_name) + bezString
+            bez_list.append(bezString)
+        return bez_list
+
+    @staticmethod
+    def get_vs_data_models(topDict, fvar):
+        otvs = topDict.VarStore.otVarStore
+        region_list = otvs.VarRegionList.Region
+        axis_tags = [axis_entry.axisTag for axis_entry in fvar.axes]
+        vs_data_models = []
+        for vsindex, var_data in enumerate(otvs.VarData):
+            vsi = VarStoreInstancer(topDict.VarStore.otVarStore, fvar.axes, {})
+            master_vsi_list = [vsi]
+            for region_idx in var_data.VarRegionIndex:
+                region = region_list[region_idx]
+                loc = {}
+                for i, axis in enumerate(region.VarRegionAxis):
+                    loc[axis_tags[i]] = axis.PeakCoord
+                vsi = VarStoreInstancer(topDict.VarStore.otVarStore, fvar.axes,
+                                        loc)
+                master_vsi_list.append(vsi)
+            vdm = VarDataModel(var_data, vsindex, master_vsi_list)
+            vs_data_models.append(vdm)
+        return vs_data_models
+
+    def merge_hinted_glyphs(self, name):
+        new_t2cs = merge_hinted_programs(self.temp_cs, self.glyph_programs,
+                                         name, self.vs_data_model)
+        if self.vsindex:
+            new_t2cs.program = [self.vsindex, 'vsindex'] + new_t2cs.program
+        self.charStrings[name] = new_t2cs
+
+
+def interpolate_cff2_charstring(charstring, gname, interpolateFromDeltas,
+                                vsindex):
+    # Interpolate charstring
+    # e.g replace blend op args with regular args,
+    # and discard vsindex op.
+    new_program = []
+    last_i = 0
+    program = charstring.program
+    for i, token in enumerate(program):
+        if token == 'vsindex':
+            if last_i != 0:
+                new_program.extend(program[last_i:i - 1])
+            last_i = i + 1
+        elif token == 'blend':
+            num_regions = charstring.getNumRegions(vsindex)
+            numMasters = 1 + num_regions
+            num_args = program[i - 1]
+            # The program list starting at program[i] is now:
+            # ..args for following operations
+            # num_args values  from the default font
+            # num_args tuples, each with numMasters-1 delta values
+            # num_blend_args
+            # 'blend'
+            argi = i - (num_args * numMasters + 1)
+            if last_i != argi:
+                new_program.extend(program[last_i:argi])
+            end_args = tuplei = argi + num_args
+            master_args = []
+            while argi < end_args:
+                next_ti = tuplei + num_regions
+                deltas = program[tuplei:next_ti]
+                val = interpolateFromDeltas(vsindex, deltas)
+                master_val = program[argi]
+                master_val += otRound(val)
+                master_args.append(master_val)
+                tuplei = next_ti
+                argi += 1
+            new_program.extend(master_args)
+            last_i = i + 1
+    if last_i != 0:
+        new_program.extend(program[last_i:])
+    return new_program
+
+
+def merge_hinted_programs(charstring, t2_programs, gname, vs_data_model):
+    num_masters = vs_data_model.num_masters
+    var_pen = CFF2CharStringMergePen([], gname, num_masters, 0)
+    charstring.outlineExtractor = MergeOutlineExtractor
+
+    for i, t2_program in enumerate(t2_programs):
+        var_pen.restart(i)
+        charstring.program = t2_program
+        charstring.draw(var_pen)
+
+    new_charstring = var_pen.getCharString(
+        private=charstring.private,
+        globalSubrs=charstring.globalSubrs,
+        var_model=vs_data_model, optimize=True)
+    return new_charstring
+
+
+@_add_method(VarStoreInstancer)
+def get_scalars(self, vsindex, region_idx):
+    varData = self._varData
+    # The index key needs to be the master value index, which includes
+    # the default font value. VarRegionIndex provides the region indices.
+    scalars = {0: 1.0}  # The default font always has a weight of 1.0
+    region_index = varData[vsindex].VarRegionIndex
+    for idx in range(region_idx):  # omit the scalar for the region.
+        scalar = self._getScalar(region_index[idx])
+        if scalar:
+            scalars[idx+1] = scalar
+    return scalars
+
+
+class VarDataModel(object):
+
+    def __init__(self, var_data, vsindex, master_vsi_list):
+        self.master_vsi_list = master_vsi_list
+        self.var_data = var_data
+        self._num_masters = len(master_vsi_list)
+        self.delta_weights = [{}]  # for default font value
+        for region_idx, vsi in enumerate(master_vsi_list[1:]):
+            scalars = vsi.get_scalars(vsindex, region_idx)
+            self.delta_weights.append(scalars)
+
+    @property
+    def num_masters(self):
+        return self._num_masters
+
+    def getDeltas(self, master_values):
+        assert len(master_values) == len(self.delta_weights)
+        out = []
+        for i, scalars in enumerate(self.delta_weights):
+            delta = master_values[i]
+            for j, scalar in scalars.items():
+                if scalar:
+                    delta -= out[j] * scalar
+            out.append(delta)
+        return out

--- a/python/psautohint/ufoFont.py
+++ b/python/psautohint/ufoFont.py
@@ -382,19 +382,21 @@ class UFOFontData:
     def isCID():
         return False
 
+    @staticmethod
+    def hasFDArray():
+        return False
+
     def convertToBez(self, name, read_hints, round_coords, doAll=False):
         # We do not yet support reading hints, so read_hints is ignored.
         width, bez, skip = self._get_or_skip_glyph(name, round_coords, doAll)
         if skip:
-            return None, width
+            return None
 
         bezString = "\n".join(bez)
         bezString = "\n".join(["% " + name, "sc", bezString, "ed", ""])
-        return bezString, width
+        return bezString
 
-    def updateFromBez(self, bezData, name, width, mm_hint_info=None):
-        # For UFO font, we don't use the width parameter:
-        # it is carried over from the input glif file.
+    def updateFromBez(self, bezData, name, mm_hint_info=None):
         layer = None
         if name in self.processedLayerGlyphMap:
             layer = PROCESSED_LAYER_NAME

--- a/tests/integration/test_mmhint.py
+++ b/tests/integration/test_mmhint.py
@@ -19,6 +19,7 @@ class Options(ACOptions):
         self.reference_font = reference
         self.hintAll = True
         self.verbose = False
+        self.verbose = False
 
 
 @pytest.mark.parametrize("base", glob.glob("%s/*/Masters" % DATA_DIR))
@@ -58,6 +59,23 @@ def test_mmotf(base, tmpdir):
 
         assert differ([str(tmpdir / basename(ref)) + ".xml",
                        str(tmpdir / basename(out)) + ".xml"])
+
+
+@pytest.mark.parametrize("otf", glob.glob("%s/vf_tests/*.otf" % DATA_DIR))
+def test_vfotf(otf, tmpdir):
+    out = str(tmpdir / basename(otf)) + ".out"
+    options = Options(None, [otf], [out])
+    options.allow_no_blues = True
+    hintFiles(options)
+
+    for path in (otf, out):
+        font = TTFont(path)
+        assert "CFF2" in font
+        writer = XMLWriter(str(tmpdir / basename(path)) + ".xml")
+        font["CFF2"].toXML(writer, font)
+        writer.close()
+    assert differ([str(tmpdir / basename(otf)) + ".xml",
+                   str(tmpdir / basename(out)) + ".xml"])
 
 
 def test_incompatible_masters(tmpdir):

--- a/tests/unittests/test_hint.py
+++ b/tests/unittests/test_hint.py
@@ -32,7 +32,7 @@ class BezFontData:
         if glyphName not in self._glyphs:
             with open(os.path.join(self._path, glyphName + ".bez")) as fp:
                 self._glyphs[glyphName] = fp.read()
-        return (self._glyphs[glyphName], 0)
+        return self._glyphs[glyphName]
 
     def getGlyphList(self):
         files = glob.glob(self._path + "/*.bez")
@@ -80,7 +80,7 @@ def normalize_glyph(glyph, name):
 
 
 def get_glyph(font, name):
-    glyph = font.convertToBez(name, True, True)[0]
+    glyph = font.convertToBez(name, True, True)
     return normalize_glyph(glyph, name)
 
 


### PR DESCRIPTION
…or MM fonts, and hinting a CFF2 variable font. Hinting the master sources for a glyph for the two cases is now identical. The latter differs from the former in that the VF charstring must first be interpolated to a regular T2 charstring for each master source font. After the hinting is done, the T2 charstrings must be merged back together into a single VF charstring.

I also renamed some variables that had different meanings for the same name. For example, 'width' in some contexts contains the advance width for a glyph. In other contexts, it contains the T2 charstring width arg, which is (advance width - CFF nominal width). I renamed all occurrences of 'width' in the latter context to 't2_width_arg'.

Refactored code in autohint.py and otffont.py to move font-format specific calls and properties into otffont.py, per Khaled's review.

Fixed new LGTM issues.