### PR TITLE
Removed unused code.

### DIFF
--- a/libpsautohint/src/eval.c
+++ b/libpsautohint/src/eval.c
@@ -269,8 +269,7 @@ static void
 VStemMiss(HintSeg* leftSeg, HintSeg* rightSeg)
 {
     Fixed ltop, lbot, lloc, rloc, rtop, rbot;
-    Fixed mndist, dx, dist;
-    Fixed l, r, minDiff, minW, w;
+    Fixed dx, l, r, minDiff, minW, w;
     int i;
     if (gNumVStems == 0)
         return;
@@ -284,17 +283,9 @@ VStemMiss(HintSeg* leftSeg, HintSeg* rightSeg)
     if (dx < gMinDist)
         return;
     /* top is always > bot, independent of YgoesUp */
-    if ((ltop >= rbot) && (lbot <= rtop)) { /* overlap */
-        Fixed overlaplen = NUMMIN(ltop, rtop) - NUMMAX(lbot, rbot);
-        Fixed minlen = NUMMIN(ltop - lbot, rtop - rbot);
-        if (minlen == overlaplen)
-            dist = dx;
-        else
-            dist = CalcOverlapDist(dx, overlaplen, minlen);
-    } else
+    if ((ltop < rbot) || (lbot > rtop))  /* does not overlap */
         return;
-    mndist = FixTwoMul(gMinDist);
-    dist = NUMMAX(dist, mndist);
+
     l = lloc;
     r = rloc;
     w = abs(r - l);


### PR DESCRIPTION
Fixes #194. Since I was as concerned that we lost useful code in eval.c::VStemMis…s() that did use these lines at some point, I tracked this back to the 1992 SunOS sources. I now recall that when PS hinting was developed, H hints were developed first, then V hint support added later. It is clear that VStemMiss() was copied from HStemMiss(), and then modified so that it does not reference 'dist', leaving some lines unneeded. This was an editing error, and these lines were never used.  I removed them.