### PR TITLE
Drop support for using autohintexe

### DIFF
--- a/python/psautohint/__main__.py
+++ b/python/psautohint/__main__.py
@@ -926,7 +926,6 @@ class ReportOptions(ACOptions):
         self.noFlex = True
         self.allow_no_blues = True
         self.logOnly = True
-        self.use_autohintexe = True
         self.inputPaths = pargs.font_paths
         self.outputPaths = pargs.output_paths
         self.report_stems = not pargs.alignment_zones

--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -71,7 +71,6 @@ class ACOptions(object):
         self.report_zones = False
         self.report_stems = False
         self.report_all_stems = False
-        self.use_autohintexe = False
 
     def __str__(self):
         # used only when debugging.
@@ -607,8 +606,7 @@ def hint_glyph(options, name, bez_glyph, fontinfo):
         hinted = hint_bez_glyph(fontinfo, bez_glyph, options.allowChanges,
                                 not options.noHintSub, options.round_coords,
                                 options.report_zones, options.report_stems,
-                                options.report_all_stems,
-                                options.use_autohintexe)
+                                options.report_all_stems)
     except PsAutoHintCError:
         raise ACHintError("%s: Failure in processing outline data." %
                           options.nameAliases.get(name, name))

--- a/tests/integration/test_hint.py
+++ b/tests/integration/test_hint.py
@@ -70,16 +70,6 @@ def test_cff(cff, tmpdir):
                    str(tmpdir / basename(out)) + ".xml"])
 
 
-def test_autohintexe(tmpdir):
-    path = "%s/dummy/font.ufo" % DATA_DIR
-    out = str(tmpdir / basename(path)) + ".out"
-    options = Options(path, out)
-    options.use_autohintexe = True
-    hintFiles(options)
-
-    assert differ([path, out])
-
-
 tx_found = False
 try:
     subprocess.check_call(["tx", "-h"])

--- a/tests/integration/test_stemhist.py
+++ b/tests/integration/test_stemhist.py
@@ -25,12 +25,10 @@ class Options(ACOptions):
     pytest.param(False, True, False, id="report_stems"),
     pytest.param(False, True, True, id="report_stems,all_stems"),
 ])
-@pytest.mark.parametrize("use_autohintexe", [False, True])
-def test_otf(zones, stems, all_stems, tmpdir, use_autohintexe):
+def test_otf(zones, stems, all_stems, tmpdir):
     path = "%s/dummy/font.otf" % DATA_DIR
     out = str(tmpdir / basename(path))
     options = Options(path, out, zones, stems, all_stems)
-    options.use_autohintexe = use_autohintexe
 
     hintFiles(options)
 

--- a/tests/unittests/test_hint.py
+++ b/tests/unittests/test_hint.py
@@ -88,8 +88,7 @@ def get_glyph(font, name):
     glob.glob("%s/unhinted/*.[uo][ft][of]" % DATA_DIR),
     glob.glob("%s/hinted/*.[uo][ft][of]" % DATA_DIR),
 ))
-@pytest.mark.parametrize("use_autohintexe", [False, True])
-def test_bez(unhinted, hinted, use_autohintexe):
+def test_bez(unhinted, hinted):
     unhinted_base = os.path.splitext(unhinted)[0]
     hinted_base = os.path.splitext(hinted)[0]
 
@@ -122,6 +121,5 @@ def test_bez(unhinted, hinted, use_autohintexe):
         hinted_otf_glyph = get_glyph(hinted_otf_font, name)
         assert hinted_otf_glyph == hinted_bez_glyph
 
-        result = hint_bez_glyph(bez_info, bez_glyph,
-                                use_autohintexe=use_autohintexe)
+        result = hint_bez_glyph(bez_info, bez_glyph)
         assert normalize_glyph(result, name) == hinted_bez_glyph


### PR DESCRIPTION
Not needed any more as the underlying issue was fixed in https://github.com/adobe-type-tools/psautohint/pull/195

Fixes https://github.com/adobe-type-tools/psautohint/issues/118

Keep building autohintexe, though, as it is still used by AFDKO’s autohint. We should stop doing that once autohint is retired.