### PR TITLE
grow gPtLstArray by doubling size instead of incrementing by five

### DIFF
--- a/libpsautohint/src/ac.c
+++ b/libpsautohint/src/ac.c
@@ -117,7 +117,7 @@ InitData(int32_t reason)
 
             /* ?? Does this cause a leak ?? */
             gPointList = NULL;
-            gMaxPtLsts = 64;
+            gMaxPtLsts = 128;
             gPtLstArray = (HintPoint**)Alloc(gMaxPtLsts * sizeof(HintPoint*));
             gPtLstIndex = 0;
             gPtLstArray[0] = NULL;

--- a/libpsautohint/src/ac.c
+++ b/libpsautohint/src/ac.c
@@ -117,7 +117,7 @@ InitData(int32_t reason)
 
             /* ?? Does this cause a leak ?? */
             gPointList = NULL;
-            gMaxPtLsts = 5;
+            gMaxPtLsts = 64;
             gPtLstArray = (HintPoint**)Alloc(gMaxPtLsts * sizeof(HintPoint*));
             gPtLstIndex = 0;
             gPtLstArray[0] = NULL;

--- a/libpsautohint/src/control.c
+++ b/libpsautohint/src/control.c
@@ -345,12 +345,13 @@ GetNewPtLst(void)
     if (gNumPtLsts >= gMaxPtLsts) { /* increase size */
         HintPoint** newArray;
         int32_t i;
-        gMaxPtLsts += 5;
-        newArray = (HintPoint**)Alloc(gMaxPtLsts * sizeof(HintPoint*));
-        for (i = 0; i < gMaxPtLsts - 5; i++) {
+        int32_t newSize = gMaxPtLsts * 2;
+        newArray = (HintPoint**)Alloc(newSize * sizeof(HintPoint*));
+        for (i = 0; i < gMaxPtLsts; i++) {
             newArray[i] = gPtLstArray[i];
         }
         gPtLstArray = newArray;
+        gMaxPtLsts = newSize;
     }
     gPtLstIndex = gNumPtLsts;
     gNumPtLsts++;


### PR DESCRIPTION
(also start with initial size of 128 instead of 5)

fixes #103 

Note: I consider this a work-around rather than a fix, but since the problem only seems to occur in an `-O3` build (i.e. *without* debug info) and only on Linux, it's a pain to debug.