### PR TITLE
Update otfFont.py

### DIFF
--- a/python/psautohint/otfFont.py
+++ b/python/psautohint/otfFont.py
@@ -25,6 +25,8 @@ import fontTools.subset.cff
 
 from . import fdTools, FontParseError
 
+# keep linting tools quiet about unused import
+assert fontTools.subset.cff is not None
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Add an assert for `fontTools.subset.cff` to keep linting/analysis tools quiet about unused import of `fontTools.subset.cff` which _is_ actually used (more succinctly: its _side-effects_, the addition of methods to the CFF and CFF2 tables, are used) but it's not obvious that this is the case and several tools complain about it.