### PR TITLE
Simplifying code to print the FDDict with --print-dflt-fddict and exiting

### DIFF
--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -31,7 +31,7 @@
 import ast
 import logging
 import os
-import re
+import sys
 import time
 from collections import defaultdict, namedtuple
 
@@ -402,28 +402,6 @@ fontInfoKeywordList = [
     'Baseline6',
 ]
 
-integerPattern = r""" -?\d+"""
-arrayPattern = r""" \[[ ,0-9]+\]"""
-stringPattern = r""" \S+"""
-counterPattern = r""" \([\S ]+\)"""
-
-
-def printFontInfo(fontInfoString):
-    for item in fontInfoKeywordList:
-        if item in ['FontName', 'FlexOK']:
-            matchingExp = item + stringPattern
-        elif item in ['VCounterChars', 'HCounterChars']:
-            matchingExp = item + counterPattern
-        elif item in ['DominantV', 'DominantH']:
-            matchingExp = item + arrayPattern
-        else:
-            matchingExp = item + integerPattern
-
-        try:
-            print('\t%s' % re.search(matchingExp, fontInfoString).group())
-        except Exception:
-            pass
-
 
 def openFile(path, options):
     font_format = get_font_format(path)
@@ -527,8 +505,8 @@ def get_fontinfo_list_withFontInfo(options, font, path, glyph_list):
                                   options.noFlex,
                                   options.vCounterGlyphs,
                                   options.hCounterGlyphs)
-        printFontInfo(str(fddict))
-        return
+        # NOTE If --print-dflt-fddict is supposed to exit the CLI run, exit it
+        sys.exit(fddict.getFontInfo())
 
     fdglyphdict, fontDictList = font.getfdInfo(options.allow_no_blues,
                                                options.noFlex,
@@ -542,7 +520,7 @@ def get_fontinfo_list_withFontInfo(options, font, path, glyph_list):
             print("Showing user-defined FontDict Values:\n")
             for fi, fontDict in enumerate(fontDictList):
                 print(fontDict.DictName)
-                printFontInfo(str(fontDict))
+                print(fontDict.getFontInfo())
                 gnameList = []
                 # item = [glyphName, [fdIndex, glyphListIndex]]
                 itemList = sorted(fdglyphdict.items(), key=lambda x: x[1][1])

--- a/python/psautohint/autohint.py
+++ b/python/psautohint/autohint.py
@@ -505,8 +505,8 @@ def get_fontinfo_list_withFontInfo(options, font, path, glyph_list):
                                   options.noFlex,
                                   options.vCounterGlyphs,
                                   options.hCounterGlyphs)
-        # NOTE If --print-dflt-fddict is supposed to exit the CLI run, exit it
-        sys.exit(fddict.getFontInfo())
+        # Exit by printing default FDDict with all lines indented by one tab
+        sys.exit("\t" + "\n\t".join(fddict.getFontInfo().split("\n")))
 
     fdglyphdict, fontDictList = font.getfdInfo(options.allow_no_blues,
                                                options.noFlex,

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,4 +1,5 @@
 import glob
+import os
 from os.path import basename
 import subprocess
 import pytest
@@ -210,7 +211,6 @@ def test_option(path, option, argument, tmpdir):
     "--no-flex",
     "--no-hint-sub",
     "--no-zones-stems",
-    "--print-dflt-fddict",
     "--print-list-fddict",
     "--report-only",
     "--verbose",
@@ -223,6 +223,22 @@ def test_argumentless_option(path, option, tmpdir):
     out = str(tmpdir / basename(path)) + ".out"
 
     autohint([path, '-o', out, option])
+
+
+def test_print_fddict(capsys):
+    dummypath = os.path.join(DATA_DIR, "dummy")
+    fontpath = os.path.join(dummypath, "font.otf")
+    fipath = os.path.join(dummypath, "fontinfo_fdd")
+    exp_path = os.path.join(dummypath, 'print_dflt_fddict_expected.txt')
+
+    with open(exp_path, 'r') as exp_f:
+        expected = exp_f.read()
+        with pytest.raises(SystemExit) as wrapped_exc:
+            autohint([fontpath,
+                      '--print-dflt-fddict',
+                      '--fontinfo-file',
+                      fipath])
+            str(wrapped_exc) == expected
 
 
 @pytest.mark.parametrize("option", [


### PR DESCRIPTION
Potential fix for #222

I'm not sure should or should--print-dflt-fddict exit or not, but with this fix it does. When omitting [this return statement](https://github.com/adobe-type-tools/psautohint/blob/master/python/psautohint/autohint.py#L532) the code continues to execute, but then a loooot of CLI spam follows, so presumably this used to exit after the print of the dflt values.

The printing of the FDDict seems to have been formatted with tabs, whereas the existing `getFontInfo` [method](https://github.com/adobe-type-tools/psautohint/blob/master/python/psautohint/fdTools.py#L114) seems to not - but without further knowledge it is hard to say if this implementation is usable or if some other kind of formatting is required.