### PR TITLE
Demote "bogus bbx" warning to info

### DIFF
--- a/libpsautohint/src/report.c
+++ b/libpsautohint/src/report.c
@@ -392,7 +392,7 @@ ReportDuplicates(Fixed x, Fixed y)
 void
 ReportBBoxBogus(Fixed llx, Fixed lly, Fixed urx, Fixed ury)
 {
-    LogMsg(WARNING, OK, "Glyph bounding box looks bogus: %g %g %g %g.",
+    LogMsg(INFO, OK, "Glyph bounding box looks bogus: %g %g %g %g.",
            FixToDbl(llx), FixToDbl(lly), FixToDbl(urx), FixToDbl(ury));
 }
 


### PR DESCRIPTION
The message will now only appear when psautohint is invoked with the `--verbose` flag.

Closes #159 
