### PR TITLE
pin pytest to 5.4.3 in coverage.yml because of logging bug in pytest 6.x.x

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
       env:
         CFLAGS: '--coverage'
       run: |
-        pip install pytest pytest-cov pytest-xdist
+        pip install pytest==5.4.3 pytest-cov pytest-xdist
         echo "::set-env name=PYTHONPATH::home/runner/work/psautohint/build/lib"
         python setup.py build --build-base build --build-platlib build/lib
         python setup.py install


### PR DESCRIPTION
If we use this command with pytest 6.0.0rc1, 6.0.0, or 6.0.1:

```
pytest -n auto tests/integration/test_cli.py tests/integration/test_hint.py
```

The test case `tests/integration/test_hint.py::test_hashmap_old_version` fails due to a missing log message.

However if we run:

```
pytest -n auto tests/integration/test_hint.py
```

it passes.

Likewise if we run the original command above with pytest 5.4.3 or earlier, it passes.

I think this an example of this pytest issue:

https://github.com/pytest-dev/pytest/issues/7335