### PR TITLE
Remove autohintexe from wheels

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -42,14 +42,3 @@ function run_tests {
     # container can lead to permission errors
     rm -rf .tox
 }
-
-# override default 'install_delocate' as a temporary workaround for
-# autohintexe embedded executable losing execute permissions on macOS
-# https://github.com/matthew-brett/delocate/issues/42
-# https://github.com/matthew-brett/delocate/pull/43
-# https://github.com/adobe-type-tools/psautohint/pull/116
-# TODO: remove this once new delocate with the above patch is released
-function install_delocate {
-    check_pip
-    $PIP_CMD install git+https://github.com/matthew-brett/delocate.git#egg=delocate
-}

--- a/python/psautohint/__init__.py
+++ b/python/psautohint/__init__.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import logging
 
 from . import _psautohint
@@ -8,17 +7,6 @@ from . import _psautohint
 log = logging.getLogger(__name__)
 
 __version__ = _psautohint.version
-
-
-AUTOHINTEXE = os.path.join(
-    os.path.dirname(__file__),
-    "autohintexe" + (".exe" if sys.platform in ("win32", "cygwin") else "")
-)
-if not os.path.isfile(AUTOHINTEXE) or not os.access(AUTOHINTEXE, os.X_OK):
-    import warnings
-    warnings.warn(
-        "embedded 'autohintexe' executable not found: %r" % AUTOHINTEXE
-    )
 
 
 class FontParseError(Exception):

--- a/python/psautohint/otfFont.py
+++ b/python/psautohint/otfFont.py
@@ -948,7 +948,7 @@ class CFFFontData:
         try:
             bezString, t2Wdth = convertT2GlyphToBez(t2CharString,
                                                     read_hints, round_coords)
-            # Note: the glyph name is important, as it is used by autohintexe
+            # Note: the glyph name is important, as it is used by the C-code
             # for various heuristics, including [hv]stem3 derivation.
             bezString = "% " + glyphName + "\n" + bezString
         except SEACError:

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ from distutils.ccompiler import show_compilers
 
 from distutils.command.build import build as _build
 from setuptools.command.build_clib import build_clib as _build_clib
-from setuptools.command.install import install as _install
-from setuptools.command.install_lib import install_lib as _install_lib
 from setuptools.command.build_ext import build_ext as _build_ext
 
 
@@ -465,63 +463,12 @@ class CustomBuildClib(_build_clib):
                                             debug=self.debug)
 
 
-class CustomInstall(_install):
-    """Sets 'install_lib' option to 'install_platlib' if distribution
-    contains any executables.
-    """
-
-    def finalize_options(self):
-        _install.finalize_options(self)
-        if self.distribution.has_executables():
-            self.install_lib = self.install_platlib
-
-
-class CustomInstallLib(_install_lib):
-    """Runs 'build_exe' if distribution contains any executables
-    """
-
-    def build(self):
-        _install_lib.build(self)
-        if not self.skip_build:
-            if self.distribution.has_executables():
-                self.run_command('build_exe')
-
-    def get_outputs(self):
-        outputs = _install_lib.get_outputs(self)
-
-        exe_outputs = self._mutate_outputs(
-            self.distribution.has_executables(),
-            'build_exe', 'build_lib', self.install_dir)
-
-        return outputs + exe_outputs
-
-
 cmdclass = {
     'build': CustomBuild,
     'build_clib': CustomBuildClib,
     'build_ext': CustomBuildExt,
     'build_exe': build_exe,
-    'install': CustomInstall,
-    'install_lib': CustomInstallLib,
 }
-
-
-try:
-    from wheel.bdist_wheel import bdist_wheel
-except ImportError:
-    pass
-else:
-
-    class CustomBDistWheel(bdist_wheel):
-        """Marks the wheel as non-pure if distribution contains any executables
-        """
-
-        def finalize_options(self):
-            bdist_wheel.finalize_options(self)
-            if self.distribution.has_executables():
-                self.root_is_pure = False
-
-    cmdclass['bdist_wheel'] = CustomBDistWheel
 
 
 libraries = [

--- a/setup.py
+++ b/setup.py
@@ -14,14 +14,6 @@ from setuptools.command.build_clib import build_clib as _build_clib
 from setuptools.command.build_ext import build_ext as _build_ext
 
 
-class CustomBuildExt(_build_ext):
-
-    def run(self):
-        if self.distribution.has_c_libraries():
-            self.run_command("build_clib")
-        _build_ext.run(self)
-
-
 class Executable(Extension):
     pass
 
@@ -435,6 +427,14 @@ class CustomBuildClib(_build_clib):
             self.compiler.create_static_lib(objects, lib_name,
                                             output_dir=self.build_clib,
                                             debug=self.debug)
+
+
+class CustomBuildExt(_build_ext):
+
+    def run(self):
+        if self.distribution.has_c_libraries():
+            self.run_command("build_clib")
+        _build_ext.run(self)
 
 
 cmdclass = {


### PR DESCRIPTION
With these changes, **autohintexe** is no longer included in the wheels.
It's still possible to build autohintexe by running the `build_exe` command.

Fixes #245 