### PR TITLE
Keep up with fontTools getDeltas API

### DIFF
--- a/python/psautohint/otfFont.py
+++ b/python/psautohint/otfFont.py
@@ -15,7 +15,7 @@ import itertools
 from fontTools.misc.psCharStrings import (T2OutlineExtractor,
                                           SimpleT2Decompiler)
 from fontTools.ttLib import TTFont, newTable
-from fontTools.misc.fixedTools import otRound
+from fontTools.misc.roundTools import noRound, otRound
 from fontTools.varLib.varStore import VarStoreInstancer
 from fontTools.varLib.cff import CFF2CharStringMergePen, MergeOutlineExtractor
 # import subset.cff is needed to load the implementation for
@@ -1497,7 +1497,7 @@ class VarDataModel(object):
     def num_masters(self):
         return self._num_masters
 
-    def getDeltas(self, master_values):
+    def getDeltas(self, master_values, *, round=noRound):
         assert len(master_values) == len(self.delta_weights)
         out = []
         for i, scalars in enumerate(self.delta_weights):
@@ -1505,5 +1505,5 @@ class VarDataModel(object):
             for j, scalar in scalars.items():
                 if scalar:
                     delta -= out[j] * scalar
-            out.append(delta)
+            out.append(round(delta))
         return out

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # 'lxml' is not a primary requirement of psautohint but it's listed here because we
 # want to have control over the version and guarantee that the XML output remains stable
 lxml==4.6.3
-fonttools[ufo,lxml]==4.21.1
+fonttools[ufo,lxml]==4.22.0

--- a/setup.py
+++ b/setup.py
@@ -584,7 +584,7 @@ setup(name="psautohint",
       python_requires='>3.6',
       setup_requires=["setuptools_scm"],
       install_requires=[
-          'fonttools[ufo]>=3.32.0',
+          'fonttools[ufo]>=4.22.0',
       ],
       extras_require={
           "testing": [


### PR DESCRIPTION
Using the current fontTools will produces errors on VFs about `getDeltas` getting too many arguments. See https://github.com/fonttools/fonttools/pull/2214.